### PR TITLE
Harden restore and storage state

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,31 @@ Resume data is stored under:
 ${XDG_DATA_HOME:-~/.local/share}/torrent-tui/resume
 ```
 
+The session registry is stored at:
+
+```text
+${XDG_DATA_HOME:-~/.local/share}/torrent-tui/session.json
+```
+
+It keeps the list of torrents the TUI should restore on startup.
+
+### What Each Setting Does
+
+| Setting | Purpose | When it applies |
+| --- | --- | --- |
+| `downloadPath` | Where torrent payload files are written and verified. | On torrent add, resume, verify, and startup restore. |
+| `torrentFolder` | Folder shown by the add-torrent dialog. | When you open the add dialog. |
+| `maxConnections` | Maximum number of peers the client will connect to per torrent. | During peer discovery and download. |
+
+### Tuning Tips
+
+- Use a fast local SSD for `downloadPath` if you want quicker verification and fewer stalls on reopen.
+- Point `torrentFolder` at the directory where you keep `.torrent` files so adding torrents is faster.
+- Lower `maxConnections` if your network or CPU struggles with many peers; raise it if you want more parallel peer selection.
+- Settings are read when the app starts. If you edit `settings.json` manually, restart the app to pick up the changes.
+- If the settings file is invalid, torrent-tui falls back to defaults and logs a config warning.
+- `session.json` and the resume files are rewritten automatically as torrent state changes, so you normally do not need to edit them by hand.
+
 ## Status
 
 `0.0.1` is a basic release intended for early CLI usage.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,7 +1,9 @@
 // Config loader - reads from ~/.config/torrent-tui/settings.json
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { getConfigDir, getConfigPath } from "../utils/paths";
+import { existsSync, readFileSync } from "node:fs";
+import { getConfigPath } from "../utils/paths";
+import { writeJsonAtomic } from "../utils/json";
+import { log } from "../torrent/metadata";
 import { type AppSettings, DEFAULT_SETTINGS, settingsSchema } from "./settings";
 
 const SETTINGS_FILE = "settings.json";
@@ -24,18 +26,14 @@ export function loadConfig(): AppSettings {
 			return result.data;
 		}
 
+		log("config", "invalid settings file — using defaults");
 		return { ...DEFAULT_SETTINGS };
 	} catch {
+		log("config", "could not read settings file — using defaults");
 		return { ...DEFAULT_SETTINGS };
 	}
 }
 
 export function saveConfig(settings: AppSettings): void {
-	try {
-		mkdirSync(getConfigDir(), { recursive: true });
-		const configPath = getConfigPath(SETTINGS_FILE);
-		writeFileSync(configPath, JSON.stringify(settings, null, 2), "utf-8");
-	} catch {
-		// Silently fail
-	}
+	writeJsonAtomic(getConfigPath(SETTINGS_FILE), settings);
 }

--- a/src/controllers/app-controller.ts
+++ b/src/controllers/app-controller.ts
@@ -26,18 +26,21 @@ export class AppController {
 	onQuit?: () => void;
 	onDialogClose?: () => void;
 	onDialogInput?: (key: string) => boolean;
-	onPauseTorrent?: (id: string) => void;
-	onResumeTorrent?: (id: string) => void;
-	onStartTorrent?: (id: string) => void;
-	onRemoveTorrent?: (id: string, deleteFiles: boolean) => void;
+	onPauseTorrent?: (id: string) => Promise<void> | void;
+	onResumeTorrent?: (id: string) => Promise<void> | void;
+	onStartTorrent?: (id: string) => Promise<void> | void;
+	onRemoveTorrent?: (id: string, deleteFiles: boolean) => Promise<void> | void;
 
 	private _confirmDialog: ConfirmDialog | null = null;
 	set confirmDialog(dialog: ConfirmDialog) {
 		this._confirmDialog = dialog;
 		dialog.onConfirm = () => {
 			this.focusMode = "global";
-			if (this.pendingDeleteId) {
-				this.onRemoveTorrent?.(this.pendingDeleteId, true);
+			const pendingDeleteId = this.pendingDeleteId;
+			if (pendingDeleteId) {
+				this.runTorrentAction("remove torrent", () =>
+					this.onRemoveTorrent?.(pendingDeleteId, true)
+				);
 				this.pendingDeleteId = null;
 			}
 		};
@@ -84,6 +87,19 @@ export class AppController {
 		const state = this.store.getState();
 		this.sidebar.update(state, this.focusArea);
 		this.contentWindow.update(this.focusArea, this.tableSelectedIndex);
+	}
+
+	private runTorrentAction(label: string, action: () => Promise<void> | void): void {
+		Promise.resolve()
+			.then(action)
+			.catch((err: unknown) => {
+				this.toastManager.show({
+					id: `action-${Date.now()}`,
+					type: "error",
+					title: `Failed to ${label}`,
+					message: err instanceof Error ? err.message : String(err),
+				});
+			});
 	}
 
 	private getSelectedId(): string | null {
@@ -150,17 +166,17 @@ export class AppController {
 				const torrent = filterTorrents(state.torrents, state.selectedView)[this.tableSelectedIndex];
 				if (!torrent) return;
 				if (torrent.status === "downloading") {
-					this.onPauseTorrent?.(id);
+					this.runTorrentAction("pause torrent", () => this.onPauseTorrent?.(id));
 				} else if (torrent.status === "paused") {
-					this.onResumeTorrent?.(id);
+					this.runTorrentAction("resume torrent", () => this.onResumeTorrent?.(id));
 				} else if (torrent.status === "stopped") {
-					this.onStartTorrent?.(id);
+					this.runTorrentAction("start torrent", () => this.onStartTorrent?.(id));
 				}
 			}
 		} else if (key.name === "d" && !key.shift) {
 			if (this.focusArea === "table") {
 				const id = this.getSelectedId();
-				if (id) this.onRemoveTorrent?.(id, false);
+				if (id) this.runTorrentAction("remove torrent", () => this.onRemoveTorrent?.(id, false));
 			}
 		} else if (key.name === "d" && key.shift) {
 			if (this.focusArea === "table") {

--- a/src/torrent/bridge.ts
+++ b/src/torrent/bridge.ts
@@ -1,15 +1,17 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import type { AppSettings } from "../config/settings";
 import type { Store, TorrentState } from "../store";
 import { getDataDir, resolvePath } from "../utils/paths";
-import { TorrentMetadata } from "./metadata";
+import { writeJsonAtomic } from "../utils/json";
+import { TorrentMetadata, log } from "./metadata";
 import { decode } from "./parser";
 import type { BencodeValue } from "./parser";
 import { TorrentSession } from "./session";
 import { announce } from "./tracker/announce";
 import { PeerManager } from "./peer/manager";
 import type { Downloader } from "./downloader";
+import { StorageManager } from "./storage";
 
 interface TorrentEntry {
 	torrentPath: string;
@@ -20,6 +22,7 @@ interface TorrentEntry {
 }
 
 interface SessionRegistry {
+	schemaVersion: number;
 	torrents: Array<{ infoHash: string; torrentPath: string }>;
 }
 
@@ -40,12 +43,14 @@ export class TorrentBridge {
 		const registryPath = this.registryPath();
 		if (!existsSync(registryPath)) return;
 
-		let registry: SessionRegistry;
+		let registry: Partial<SessionRegistry>;
 		try {
-			registry = JSON.parse(readFileSync(registryPath, "utf-8")) as SessionRegistry;
+			registry = JSON.parse(readFileSync(registryPath, "utf-8")) as Partial<SessionRegistry>;
 		} catch {
 			return;
 		}
+
+		if (!Array.isArray(registry.torrents)) return;
 
 		for (const { infoHash, torrentPath } of registry.torrents) {
 			if (!existsSync(torrentPath)) continue;
@@ -54,8 +59,16 @@ export class TorrentBridge {
 				const actualId = Buffer.from(metadata.infoHash).toString("hex");
 				if (actualId !== infoHash) continue;
 
-				const downloadedPieces = this.loadResumeCount(infoHash);
-				const status = downloadedPieces >= metadata.pieceCount ? "seeding" : "stopped";
+				const resumeCount = this.loadResumeCount(infoHash);
+				const storage = new StorageManager(metadata, this.downloadPath);
+				const summary = await storage.verifyAll({ tolerateMissing: true });
+				const downloadedPieces = storage.downloadedCount;
+				const status: TorrentState["status"] =
+					downloadedPieces === metadata.pieceCount
+						? "seeding"
+						: downloadedPieces < resumeCount || summary.corrupt > 0
+							? "error"
+							: "stopped";
 				const entry: TorrentEntry = {
 					torrentPath,
 					session: null,
@@ -75,6 +88,7 @@ export class TorrentBridge {
 					},
 				};
 				this.torrents.set(infoHash, entry);
+				log("restore", `${metadata.name}   ${downloadedPieces}/${metadata.pieceCount} pieces   ${status}`);
 			} catch {
 				// skip invalid/unreadable torrent files
 			}
@@ -264,17 +278,11 @@ export class TorrentBridge {
 	}
 
 	private saveRegistry(): void {
-		const dir = getDataDir();
-		if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 		const entries = [...this.torrents.entries()].map(([infoHash, entry]) => ({
 			infoHash,
 			torrentPath: entry.torrentPath,
 		}));
-		try {
-			writeFileSync(this.registryPath(), JSON.stringify({ torrents: entries }, null, 2), "utf-8");
-		} catch {
-			// non-fatal
-		}
+		writeJsonAtomic(this.registryPath(), { schemaVersion: 1, torrents: entries });
 	}
 
 	private updateEntry(id: string, partial: Partial<TorrentState>): void {

--- a/src/torrent/downloader.ts
+++ b/src/torrent/downloader.ts
@@ -1,10 +1,11 @@
 import { EventEmitter } from "node:events";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { SHA1 } from "bun";
 import { log } from "./metadata.ts";
 import { PiecePicker } from "./piece-picker.ts";
 import { getDataDir } from "../utils/paths.ts";
+import { writeJsonAtomic } from "../utils/json";
 import type { TorrentMetadata } from "./metadata.ts";
 import type { StorageManager } from "./storage.ts";
 import type { PeerManager } from "./peer/manager.ts";
@@ -329,16 +330,14 @@ export class Downloader extends EventEmitter {
 
 	private saveResume(): void {
 		const path = this.resumePath();
-		const dir = join(getDataDir(), "resume");
-		if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-
 		const data = {
+			schemaVersion: 1,
 			infoHash: Buffer.from(this.metadata.infoHash).toString("hex"),
 			downloadPath: this.downloadPath,
 			downloadedPieces: [...this.storage.getDownloadedPieces()],
 			savedAt: Math.floor(Date.now() / 1000),
 		};
-		writeFileSync(path, JSON.stringify(data), "utf-8");
+		writeJsonAtomic(path, data);
 	}
 }
 

--- a/src/torrent/storage.ts
+++ b/src/torrent/storage.ts
@@ -51,20 +51,39 @@ export class StorageManager {
 	}
 
 	readPieceSync(pieceIndex: number): Buffer {
+		const data = this.readPieceMaybeSync(pieceIndex, false);
+		if (!data) {
+			throw new Error(`Unable to read piece ${pieceIndex}`);
+		}
+		return data;
+	}
+
+	private readPieceMaybeSync(pieceIndex: number, tolerateMissing: boolean): Buffer | null {
 		const ranges = this.metadata.pieceToFileRanges(pieceIndex);
 		const isLastPiece = pieceIndex === this.metadata.pieceCount - 1;
 		const pieceLen = isLastPiece
 			? this.metadata.totalSize - pieceIndex * this.metadata.pieceLength
 			: this.metadata.pieceLength;
 
-		const result = Buffer.allocUnsafe(pieceLen);
+		const result = Buffer.alloc(pieceLen);
 		let written = 0;
 
 		for (const { file, fileOffset, length } of ranges) {
 			const fullPath = join(this.downloadPath, file.path);
+			if (!existsSync(fullPath)) {
+				if (tolerateMissing) return null;
+				throw new Error(`Missing file: ${fullPath}`);
+			}
 			const fd = openSync(fullPath, "r");
-			readSync(fd, result, written, length, fileOffset);
-			closeSync(fd);
+			try {
+				const bytesRead = readSync(fd, result, written, length, fileOffset);
+				if (bytesRead !== length) {
+					if (tolerateMissing) return null;
+					throw new Error(`Short read: ${fullPath}`);
+				}
+			} finally {
+				closeSync(fd);
+			}
 			written += length;
 		}
 
@@ -82,8 +101,14 @@ export class StorageManager {
 		for (const { file, fileOffset, length } of ranges) {
 			const fullPath = join(this.downloadPath, file.path);
 			const fd = openSync(fullPath, "r+");
-			writeSync(fd, data, offset, length, fileOffset);
-			closeSync(fd);
+			try {
+				const bytesWritten = writeSync(fd, data, offset, length, fileOffset);
+				if (bytesWritten !== length) {
+					throw new Error(`Short write: ${fullPath}`);
+				}
+			} finally {
+				closeSync(fd);
+			}
 			offset += length;
 		}
 
@@ -98,7 +123,8 @@ export class StorageManager {
 		const expected = this.metadata.pieceHashes[pieceIndex];
 		if (!expected) return false;
 
-		const data = this.readPieceSync(pieceIndex);
+		const data = this.readPieceMaybeSync(pieceIndex, true);
+		if (!data) return false;
 		if (isAllZero(data)) return false;
 
 		const actual = new SHA1().update(data).digest() as unknown as Uint8Array;
@@ -106,28 +132,18 @@ export class StorageManager {
 	}
 
 	// Opens each file once and reads through it sequentially — no per-piece open/close.
-	async verifyAll(): Promise<{ valid: number; missing: number; corrupt: number }> {
+	async verifyAll(options: { tolerateMissing?: boolean } = {}): Promise<{ valid: number; missing: number; corrupt: number }> {
+		const tolerateMissing = options.tolerateMissing ?? false;
 		let valid = 0;
 		let missing = 0;
 		let corrupt = 0;
-
-		const pieceBuf = Buffer.allocUnsafe(this.metadata.pieceLength);
+		this.downloadedPieces.clear();
 
 		for (let i = 0; i < this.metadata.pieceCount; i++) {
-			const isLastPiece = i === this.metadata.pieceCount - 1;
-			const pieceLen = isLastPiece
-				? this.metadata.totalSize - i * this.metadata.pieceLength
-				: this.metadata.pieceLength;
-
-			const data = pieceBuf.subarray(0, pieceLen);
-			let written = 0;
-
-			for (const { file, fileOffset, length } of this.metadata.pieceToFileRanges(i)) {
-				const fullPath = join(this.downloadPath, file.path);
-				const fd = openSync(fullPath, "r");
-				readSync(fd, data, written, length, fileOffset);
-				closeSync(fd);
-				written += length;
+			const data = this.readPieceMaybeSync(i, tolerateMissing);
+			if (!data) {
+				missing++;
+				continue;
 			}
 
 			if (isAllZero(data)) {

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,0 +1,17 @@
+import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export function writeJsonAtomic(path: string, value: unknown): void {
+	const tmpPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+	try {
+		mkdirSync(dirname(path), { recursive: true });
+		writeFileSync(tmpPath, JSON.stringify(value, null, 2), "utf-8");
+		renameSync(tmpPath, path);
+	} catch {
+		try {
+			if (existsSync(tmpPath)) rmSync(tmpPath, { force: true });
+		} catch {
+			// Silently ignore cleanup failures.
+		}
+	}
+}


### PR DESCRIPTION
Summary:
- Revalidate restored torrents against on-disk files before restoring UI state.
- Make storage reads/writes fail on short IO instead of trusting partial data.
-  Add atomic JSON persistence and document settings/state files so tuning is clearer.

Checks:
- bun run typecheck
- bun run smoke