### PR TITLE
Add engine test fixtures and tracker parser coverage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+      - name: Test
+        run: bun test
+
       - name: CLI smoke
         run: |
           chmod +x bin/torrent-tui

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 # IntelliJ based IDEs
 .idea
 
+# Agent-local files
+.agents
+.claude
+
 # Finder (MacOS) folder config
 .DS_Store
 
@@ -38,3 +42,6 @@ PLAN.md
 
 # Test torrent files
 *.torrent
+
+# Competitive analysis report
+REPORT.md

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 **A terminal BitTorrent client for focused download management.** Add `.torrent` files, track active transfers, and manage sessions from a clean keyboard-driven interface.
 
 [![npm version](https://img.shields.io/npm/v/torrent-tui?style=for-the-badge&logo=npm)](https://www.npmjs.com/package/torrent-tui)
+[![gzipped](https://img.shields.io/badge/gzipped-39%20KB-2563eb?style=for-the-badge)](https://www.npmjs.com/package/torrent-tui)
+[![npm unpacked size](https://img.shields.io/npm/unpacked-size/torrent-tui?style=for-the-badge)](https://www.npmjs.com/package/torrent-tui)
 [![CI](https://img.shields.io/github/actions/workflow/status/ryadios/torrent-tui/release.yml?branch=main&style=for-the-badge&logo=github)](https://github.com/ryadios/torrent-tui/actions/workflows/ci.yml)
 [![license](https://img.shields.io/npm/l/torrent-tui?style=for-the-badge)](./LICENSE)
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
 		"dev": "bun --watch src/index.ts",
 		"check": "bun src/index.ts --download",
 		"smoke": "bin/torrent-tui --help && bin/torrent-tui --version && if bin/torrent-tui nope.txt; then echo \"Expected invalid torrent path to fail\"; exit 1; fi",
+		"test": "bun test",
+		"test:watch": "bun test --watch",
 		"typecheck": "tsc --noEmit",
 		"check:fix": "biome check --write --unsafe",
-		"release:check": "bun run typecheck && bun publish --dry-run"
+		"release:check": "bun run typecheck && bun test && bun publish --dry-run"
 	},
 	"keywords": [
 		"bittorrent",

--- a/src/torrent/tracker/http-tracker.ts
+++ b/src/torrent/tracker/http-tracker.ts
@@ -1,8 +1,8 @@
-import { decode } from "../parser.ts";
-import { log } from "../metadata.ts";
-import { getPeerId } from "../peer/peer-id.ts";
 import type { TorrentMetadata } from "../metadata.ts";
-import type { PeerInfo, TrackerResponse } from "../types.ts";
+import { log } from "../metadata.ts";
+import { decode } from "../parser.ts";
+import { getPeerId } from "../peer/peer-id.ts";
+import type { PeerInfo } from "../types.ts";
 
 const TEXT_DECODER = new TextDecoder();
 
@@ -18,7 +18,7 @@ function encodeBytes(buf: Uint8Array): string {
 			byte === 0x2d || // -
 			byte === 0x5f || // _
 			byte === 0x2e || // .
-			byte === 0x7e    // ~
+			byte === 0x7e // ~
 		) {
 			result += String.fromCharCode(byte);
 		} else {
@@ -28,20 +28,33 @@ function encodeBytes(buf: Uint8Array): string {
 	return result;
 }
 
-function parseDictPeers(list: import("../parser.ts").BencodeValue[]): PeerInfo[] {
+export function parseHTTPDictionaryPeers(
+	list: import("../parser.ts").BencodeValue[],
+): PeerInfo[] {
 	const peers: PeerInfo[] = [];
 	for (const entry of list) {
-		if (typeof entry !== "object" || entry === null || Array.isArray(entry) || entry instanceof Uint8Array) continue;
-		const ipRaw = entry["ip"];
-		const port = entry["port"];
+		if (
+			typeof entry !== "object" ||
+			entry === null ||
+			Array.isArray(entry) ||
+			entry instanceof Uint8Array
+		)
+			continue;
+		const ipRaw = entry.ip;
+		const port = entry.port;
 		if (typeof port !== "number") continue;
-		const ip = ipRaw instanceof Uint8Array ? TEXT_DECODER.decode(ipRaw) : typeof ipRaw === "string" ? ipRaw : null;
+		const ip =
+			ipRaw instanceof Uint8Array
+				? TEXT_DECODER.decode(ipRaw)
+				: typeof ipRaw === "string"
+					? ipRaw
+					: null;
 		if (ip) peers.push({ ip, port });
 	}
 	return peers;
 }
 
-function parseCompactPeers(data: Uint8Array): PeerInfo[] {
+export function parseHTTPCompactPeers(data: Uint8Array): PeerInfo[] {
 	const peers: PeerInfo[] = [];
 	if (data.length % 6 !== 0) return peers;
 	for (let i = 0; i < data.length; i += 6) {
@@ -50,6 +63,44 @@ function parseCompactPeers(data: Uint8Array): PeerInfo[] {
 		peers.push({ ip, port });
 	}
 	return peers;
+}
+
+export function parseHTTPTrackerResponse(buffer: Uint8Array): PeerInfo[] {
+	const decoded = decode(buffer);
+
+	if (
+		typeof decoded !== "object" ||
+		decoded === null ||
+		Array.isArray(decoded) ||
+		decoded instanceof Uint8Array
+	) {
+		throw new Error("Invalid tracker response");
+	}
+
+	if ("failure reason" in decoded) {
+		const reason = decoded["failure reason"];
+		const message =
+			reason instanceof Uint8Array
+				? TEXT_DECODER.decode(reason)
+				: typeof reason === "string"
+					? reason
+					: "unknown failure";
+		throw new Error(`Tracker failure: ${message}`);
+	}
+
+	const peersRaw = decoded.peers;
+
+	// Compact format: binary blob, 6 bytes per IPv4 peer
+	if (peersRaw instanceof Uint8Array) {
+		return parseHTTPCompactPeers(peersRaw);
+	}
+
+	// Dictionary format: list of {ip, port, peer id} dicts (used for IPv6 or non-compact)
+	if (Array.isArray(peersRaw)) {
+		return parseHTTPDictionaryPeers(peersRaw);
+	}
+
+	return [];
 }
 
 async function announceToTracker(
@@ -76,40 +127,15 @@ async function announceToTracker(
 	// AbortSignal.timeout doesn't abort TCP-level hangs in Bun — use Promise.race
 	const res = await Promise.race([
 		fetch(fullUrl, { headers: { "User-Agent": "torrent-tui/0.1" } }),
-		new Promise<never>((_, rej) => setTimeout(() => rej(new Error("The operation timed out.")), 10_000)),
+		new Promise<never>((_, rej) =>
+			setTimeout(() => rej(new Error("The operation timed out.")), 10_000),
+		),
 	]);
 
 	if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
 	const buffer = new Uint8Array(await res.arrayBuffer());
-	const decoded = decode(buffer);
-
-	if (
-		typeof decoded !== "object" ||
-		decoded === null ||
-		Array.isArray(decoded) ||
-		decoded instanceof Uint8Array
-	) {
-		throw new Error("Invalid tracker response");
-	}
-
-	if ("failure reason" in decoded) {
-		throw new Error(`Tracker failure: ${TEXT_DECODER.decode(decoded["failure reason"] as Uint8Array)}`);
-	}
-
-	const peersRaw = decoded["peers"];
-
-	// Compact format: binary blob, 6 bytes per IPv4 peer
-	if (peersRaw instanceof Uint8Array) {
-		return parseCompactPeers(peersRaw);
-	}
-
-	// Dictionary format: list of {ip, port, peer id} dicts (used for IPv6 or non-compact)
-	if (Array.isArray(peersRaw)) {
-		return parseDictPeers(peersRaw);
-	}
-
-	return [];
+	return parseHTTPTrackerResponse(buffer);
 }
 
 export async function announceHTTP(
@@ -118,9 +144,13 @@ export async function announceHTTP(
 	numwant = 50,
 ): Promise<PeerInfo[]> {
 	const peerId = getPeerId();
-	const urls = [...new Set(
-		metadata.announceList.flat().filter((u) => u.startsWith("http://") || u.startsWith("https://")),
-	)];
+	const urls = [
+		...new Set(
+			metadata.announceList
+				.flat()
+				.filter((u) => u.startsWith("http://") || u.startsWith("https://")),
+		),
+	];
 
 	const results = await Promise.allSettled(
 		urls.map((u) => announceToTracker(u, metadata, peerId, port, numwant)),
@@ -135,7 +165,8 @@ export async function announceHTTP(
 			peers.push(...r.value);
 			log("tracker", `${url}   ${r.value.length} peers`);
 		} else {
-			const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
+			const reason =
+				r.reason instanceof Error ? r.reason.message : String(r.reason);
 			log("tracker", `${url}   failed  ${reason}`);
 		}
 	}

--- a/src/torrent/tracker/udp-tracker.ts
+++ b/src/torrent/tracker/udp-tracker.ts
@@ -1,9 +1,9 @@
-import { createSocket } from "node:dgram";
 import { randomBytes } from "node:crypto";
+import { createSocket } from "node:dgram";
+import type { TorrentMetadata } from "../metadata.ts";
 import { log } from "../metadata.ts";
 import { getPeerId } from "../peer/peer-id.ts";
-import type { TorrentMetadata } from "../metadata.ts";
-import type { PeerInfo } from "../types.ts";
+import type { PeerInfo, TrackerResponse } from "../types.ts";
 
 const CONNECT_MAGIC = 0x41727101980n; // BEP 15 magic connection ID
 const CONNECT_ACTION = 0;
@@ -34,33 +34,70 @@ function buildAnnounceRequest(
 	const view = new DataView(buf.buffer);
 	let offset = 0;
 
-	view.setBigUint64(offset, connId); offset += 8;
-	view.setInt32(offset, ANNOUNCE_ACTION); offset += 4;
+	view.setBigUint64(offset, connId);
+	offset += 8;
+	view.setInt32(offset, ANNOUNCE_ACTION);
+	offset += 4;
 	const txId = randomTransactionId();
-	view.setUint32(offset, txId); offset += 4;
-	buf.set(metadata.infoHash, offset); offset += 20;
-	buf.set(getPeerId(), offset); offset += 20;
-	view.setBigInt64(offset, 0n); offset += 8;            // downloaded
-	view.setBigInt64(offset, BigInt(metadata.totalSize)); offset += 8; // left
-	view.setBigInt64(offset, 0n); offset += 8;            // uploaded
-	view.setInt32(offset, 2); offset += 4;                // event: started
-	view.setUint32(offset, 0); offset += 4;               // ip: default
-	view.setUint32(offset, 0); offset += 4;               // key
-	view.setInt32(offset, 50); offset += 4;               // num_want
-	view.setUint16(offset, listenPort);                    // port
+	view.setUint32(offset, txId);
+	offset += 4;
+	buf.set(metadata.infoHash, offset);
+	offset += 20;
+	buf.set(getPeerId(), offset);
+	offset += 20;
+	view.setBigInt64(offset, 0n);
+	offset += 8; // downloaded
+	view.setBigInt64(offset, BigInt(metadata.totalSize));
+	offset += 8; // left
+	view.setBigInt64(offset, 0n);
+	offset += 8; // uploaded
+	view.setInt32(offset, 2);
+	offset += 4; // event: started
+	view.setUint32(offset, 0);
+	offset += 4; // ip: default
+	view.setUint32(offset, 0);
+	offset += 4; // key
+	view.setInt32(offset, 50);
+	offset += 4; // num_want
+	view.setUint16(offset, listenPort); // port
 
 	return { buf, txId };
 }
 
-function parseCompactPeers(buf: Buffer, offset: number): PeerInfo[] {
+export function parseUDPCompactPeers(
+	buf: Uint8Array,
+	offset: number,
+): PeerInfo[] {
 	const peers: PeerInfo[] = [];
+	if ((buf.length - offset) % 6 !== 0) {
+		throw new Error("Invalid UDP compact peer data");
+	}
 	while (offset + 6 <= buf.length) {
 		const ip = `${buf[offset]}.${buf[offset + 1]}.${buf[offset + 2]}.${buf[offset + 3]}`;
-		const port = buf.readUInt16BE(offset + 4);
+		const port = ((buf[offset + 4] ?? 0) << 8) | (buf[offset + 5] ?? 0);
 		peers.push({ ip, port });
 		offset += 6;
 	}
 	return peers;
+}
+
+export function parseUDPAnnounceResponse(
+	buf: Uint8Array,
+	expectedTxId: number,
+): TrackerResponse {
+	if (buf.length < 20) throw new Error("UDP announce response too short");
+	const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+	if (view.getInt32(0) !== ANNOUNCE_ACTION)
+		throw new Error("bad announce action");
+	if (view.getUint32(4) !== expectedTxId)
+		throw new Error("announce txId mismatch");
+
+	return {
+		interval: view.getInt32(8),
+		incomplete: view.getInt32(12),
+		complete: view.getInt32(16),
+		peers: parseUDPCompactPeers(buf, 20),
+	};
 }
 
 function sendAndReceive(
@@ -80,7 +117,10 @@ function sendAndReceive(
 		});
 
 		socket.send(buf, port, host, (err) => {
-			if (err) { clearTimeout(timer); reject(err); }
+			if (err) {
+				clearTimeout(timer);
+				reject(err);
+			}
 		});
 	});
 }
@@ -104,19 +144,21 @@ export async function announceUDP(
 			const connectResp = await sendAndReceive(socket, connectBuf, host, port);
 
 			const view = new DataView(connectResp.buffer, connectResp.byteOffset);
-			if (view.getInt32(0) !== CONNECT_ACTION) throw new Error("bad connect action");
-			if (view.getUint32(4) !== connectTx) throw new Error("connect txId mismatch");
+			if (view.getInt32(0) !== CONNECT_ACTION)
+				throw new Error("bad connect action");
+			if (view.getUint32(4) !== connectTx)
+				throw new Error("connect txId mismatch");
 			const connId = view.getBigUint64(8);
 
 			// Step 2: announce
-			const { buf: annBuf, txId: annTx } = buildAnnounceRequest(connId, metadata, listenPort);
+			const { buf: annBuf, txId: annTx } = buildAnnounceRequest(
+				connId,
+				metadata,
+				listenPort,
+			);
 			const annResp = await sendAndReceive(socket, annBuf, host, port);
 
-			const annView = new DataView(annResp.buffer, annResp.byteOffset);
-			if (annView.getInt32(0) !== ANNOUNCE_ACTION) throw new Error("bad announce action");
-			if (annView.getUint32(4) !== annTx) throw new Error("announce txId mismatch");
-
-			const peers = parseCompactPeers(annResp, 20);
+			const { peers } = parseUDPAnnounceResponse(annResp, annTx);
 			log("tracker", `udp://${label}   ${peers.length} peers`);
 			return peers;
 		} catch (err) {

--- a/tests/helpers/bytes.ts
+++ b/tests/helpers/bytes.ts
@@ -1,0 +1,46 @@
+import { SHA1 } from "bun";
+
+const TEXT_ENCODER = new TextEncoder();
+
+export function bytes(value: string): Uint8Array {
+	return TEXT_ENCODER.encode(value);
+}
+
+export function concatBytes(parts: Uint8Array[]): Uint8Array {
+	const total = parts.reduce((sum, part) => sum + part.length, 0);
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const part of parts) {
+		out.set(part, offset);
+		offset += part.length;
+	}
+	return out;
+}
+
+export function sha1(data: Uint8Array): Uint8Array {
+	return new SHA1().update(data).digest() as unknown as Uint8Array;
+}
+
+export function hex(data: Uint8Array): string {
+	return Buffer.from(data).toString("hex");
+}
+
+export function splitPieces(
+	content: Uint8Array,
+	pieceLength: number,
+): Uint8Array[] {
+	const pieces: Uint8Array[] = [];
+	for (let offset = 0; offset < content.length; offset += pieceLength) {
+		pieces.push(content.slice(offset, offset + pieceLength));
+	}
+	return pieces;
+}
+
+export function pieceHashBytes(
+	content: Uint8Array,
+	pieceLength: number,
+): Uint8Array {
+	return concatBytes(
+		splitPieces(content, pieceLength).map((piece) => sha1(piece)),
+	);
+}

--- a/tests/helpers/fakes.ts
+++ b/tests/helpers/fakes.ts
@@ -1,0 +1,113 @@
+import { EventEmitter } from "node:events";
+import type { PeerConnection } from "../../src/torrent/peer/connection.ts";
+import type { PeerManager } from "../../src/torrent/peer/manager.ts";
+
+export interface RecordedRequest {
+	index: number;
+	begin: number;
+	length: number;
+}
+
+export class FakePeer extends EventEmitter {
+	readonly address: string;
+	readonly port: number;
+	peerId = "-FAKE000-abcdefgh1234";
+	amChoked = false;
+	amInterested = false;
+	peerChoked = false;
+	peerInterested = false;
+	piecesBitfield = new Uint8Array(0);
+	suppressDisconnect = false;
+	downloadedThisInterval = 0;
+	uploadedThisInterval = 0;
+	downloadBytesPerSec = 0;
+	uploadBytesPerSec = 0;
+	readonly requests: RecordedRequest[] = [];
+	readonly cancels: RecordedRequest[] = [];
+	readonly haves: number[] = [];
+	readonly bitfields: Uint8Array[] = [];
+	destroyed = false;
+
+	constructor(
+		address: string,
+		port: number,
+		private readonly pieces: Set<number>,
+	) {
+		super();
+		this.address = address;
+		this.port = port;
+	}
+
+	hasPiece(index: number): boolean {
+		return this.pieces.has(index);
+	}
+
+	countPiecesPublic(): number {
+		return this.pieces.size;
+	}
+
+	sendInterested(): void {
+		this.amInterested = true;
+	}
+
+	sendNotInterested(): void {
+		this.amInterested = false;
+	}
+
+	sendRequest(index: number, begin: number, length: number): void {
+		this.requests.push({ index, begin, length });
+	}
+
+	sendCancel(index: number, begin: number, length: number): void {
+		this.cancels.push({ index, begin, length });
+	}
+
+	sendHave(index: number): void {
+		this.haves.push(index);
+	}
+
+	sendBitfield(bitfield: Uint8Array): void {
+		this.bitfields.push(bitfield);
+	}
+
+	sendChoke(): void {
+		this.peerChoked = true;
+	}
+
+	sendUnchoke(): void {
+		this.peerChoked = false;
+	}
+
+	sendPiece(): void {
+		this.uploadedThisInterval += 1;
+	}
+
+	destroy(): void {
+		this.destroyed = true;
+		this.emit("disconnect");
+	}
+
+	asConnection(): PeerConnection {
+		return this as unknown as PeerConnection;
+	}
+}
+
+export class FakePeerManager extends EventEmitter {
+	readonly connections: Map<string, PeerConnection> = new Map();
+
+	constructor(peers: FakePeer[] = []) {
+		super();
+		for (const peer of peers) {
+			this.connections.set(`${peer.address}:${peer.port}`, peer.asConnection());
+		}
+	}
+
+	addPeer(peer: FakePeer): void {
+		this.connections.set(`${peer.address}:${peer.port}`, peer.asConnection());
+		this.emit("peerAdded", peer.asConnection());
+	}
+
+	asManager(): PeerManager {
+		return this as unknown as PeerManager;
+	}
+}

--- a/tests/helpers/temp.ts
+++ b/tests/helpers/temp.ts
@@ -1,0 +1,43 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export function makeTempDir(prefix = "torrent-tui-test-"): string {
+	return mkdtempSync(join(tmpdir(), prefix));
+}
+
+export async function withTempDir<T>(
+	fn: (dir: string) => T | Promise<T>,
+): Promise<T> {
+	const dir = makeTempDir();
+	try {
+		return await fn(dir);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+export async function withIsolatedAppData<T>(
+	fn: (dir: string) => T | Promise<T>,
+): Promise<T> {
+	const dir = makeTempDir("torrent-tui-data-");
+	const previousHome = process.env.HOME;
+	const previousXdgDataHome = process.env.XDG_DATA_HOME;
+	try {
+		process.env.HOME = dir;
+		process.env.XDG_DATA_HOME = join(dir, "data");
+		return await fn(dir);
+	} finally {
+		restoreEnv("HOME", previousHome);
+		restoreEnv("XDG_DATA_HOME", previousXdgDataHome);
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[name];
+		return;
+	}
+	process.env[name] = value;
+}

--- a/tests/helpers/torrent-fixtures.ts
+++ b/tests/helpers/torrent-fixtures.ts
@@ -1,0 +1,94 @@
+import { TorrentMetadata } from "../../src/torrent/metadata.ts";
+import type { BencodeValue } from "../../src/torrent/parser.ts";
+import { decode, encode } from "../../src/torrent/parser.ts";
+import { bytes, concatBytes, pieceHashBytes } from "./bytes.ts";
+
+export interface TorrentFixture {
+	raw: Uint8Array;
+	metadata: TorrentMetadata;
+	content: Uint8Array;
+	info: { [key: string]: BencodeValue };
+}
+
+export function metadataFromRaw(raw: Uint8Array): TorrentMetadata {
+	const decoded = decode(raw);
+	if (
+		typeof decoded !== "object" ||
+		decoded === null ||
+		Array.isArray(decoded) ||
+		decoded instanceof Uint8Array
+	) {
+		throw new Error("Fixture did not decode to a torrent dictionary");
+	}
+	return new TorrentMetadata(decoded as { [key: string]: BencodeValue }, raw);
+}
+
+export function singleFileTorrentFixture(
+	options: {
+		name?: string;
+		content?: Uint8Array;
+		pieceLength?: number;
+		announce?: string;
+		announceList?: string[][];
+	} = {},
+): TorrentFixture {
+	const name = options.name ?? "sample.bin";
+	const content = options.content ?? bytes("abcdefghijkl");
+	const pieceLength = options.pieceLength ?? 4;
+	const info: { [key: string]: BencodeValue } = {
+		length: content.length,
+		name,
+		"piece length": pieceLength,
+		pieces: pieceHashBytes(content, pieceLength),
+	};
+	const torrent = buildTorrentDictionary(info, options);
+	const raw = encode(torrent);
+	return { raw, metadata: metadataFromRaw(raw), content, info };
+}
+
+export function multiFileTorrentFixture(
+	options: {
+		name?: string;
+		files?: Array<{ path: string[]; content: Uint8Array }>;
+		pieceLength?: number;
+		announce?: string;
+	} = {},
+): TorrentFixture {
+	const name = options.name ?? "album";
+	const files = options.files ?? [
+		{ path: ["disc1", "a.txt"], content: bytes("abc") },
+		{ path: ["disc1", "b.txt"], content: bytes("defgh") },
+		{ path: ["c.txt"], content: bytes("ijkl") },
+	];
+	const content = concatBytes(files.map((file) => file.content));
+	const pieceLength = options.pieceLength ?? 5;
+	const info: { [key: string]: BencodeValue } = {
+		files: files.map((file) => ({
+			length: file.content.length,
+			path: file.path,
+		})),
+		name,
+		"piece length": pieceLength,
+		pieces: pieceHashBytes(content, pieceLength),
+	};
+	const torrent = buildTorrentDictionary(info, options);
+	const raw = encode(torrent);
+	return { raw, metadata: metadataFromRaw(raw), content, info };
+}
+
+function buildTorrentDictionary(
+	info: { [key: string]: BencodeValue },
+	options: {
+		announce?: string;
+		announceList?: string[][];
+	},
+): { [key: string]: BencodeValue } {
+	const torrent: { [key: string]: BencodeValue } = {
+		announce: options.announce ?? "http://tracker.example/announce",
+		info,
+	};
+	if (options.announceList) {
+		torrent["announce-list"] = options.announceList;
+	}
+	return torrent;
+}

--- a/tests/torrent/parser-metadata.test.ts
+++ b/tests/torrent/parser-metadata.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+import { TorrentMetadata } from "../../src/torrent/metadata.ts";
+import type { BencodeValue } from "../../src/torrent/parser.ts";
+import {
+	decode,
+	encode,
+	extractInfoBytes,
+	parseStringB,
+} from "../../src/torrent/parser.ts";
+import { bytes, hex } from "../helpers/bytes.ts";
+import {
+	metadataFromRaw,
+	multiFileTorrentFixture,
+	singleFileTorrentFixture,
+} from "../helpers/torrent-fixtures.ts";
+
+describe("bencode parser", () => {
+	test("decodes primitive and nested values", () => {
+		expect(decode(bytes("i42e"))).toBe(42);
+		expect(Array.from(decode(bytes("4:spam")) as Uint8Array)).toEqual(
+			Array.from(bytes("spam")),
+		);
+		expect(decode(bytes("li1e3:twoe"))).toEqual([1, bytes("two")]);
+		expect(decode(bytes("d1:ali1ei2ee1:bi3ee"))).toEqual({
+			a: [1, 2],
+			b: 3,
+		});
+	});
+
+	test("decodes text strings when requested", () => {
+		expect(parseStringB(bytes("5:hello"), 0)).toEqual(["hello", 7]);
+	});
+
+	test("round trips bencode values with sorted dictionary keys", () => {
+		const value: { [key: string]: BencodeValue } = {
+			z: 1,
+			a: "x",
+			list: [bytes("raw"), -2],
+		};
+		const encoded = encode(value);
+
+		expect(Buffer.from(encoded).toString()).toBe(
+			"d1:a1:x4:listl3:rawi-2ee1:zi1ee",
+		);
+		expect(decode(encoded)).toEqual({
+			a: bytes("x"),
+			list: [bytes("raw"), -2],
+			z: 1,
+		});
+	});
+
+	test("rejects malformed bencode", () => {
+		expect(() => decode(bytes("i12"))).toThrow("Unterminated integer");
+		expect(() => decode(bytes("4:abc"))).toThrow(
+			"Invalid string: length exceeds data",
+		);
+		expect(() => decode(bytes("i1ee"))).toThrow("Extra data");
+		expect(() => decode(bytes("x"))).toThrow("Invalid bencode type");
+	});
+
+	test("extracts raw info bytes without depending on top-level key order", () => {
+		const fixture = singleFileTorrentFixture();
+
+		expect(extractInfoBytes(fixture.raw)).toEqual(encode(fixture.info));
+		expect(hex(fixture.metadata.infoHash)).toBe(
+			"f0e16d3ed965f1025c51c11e78e664cda769d6a0",
+		);
+	});
+});
+
+describe("TorrentMetadata", () => {
+	test("parses single-file metadata", () => {
+		const fixture = singleFileTorrentFixture({
+			announceList: [
+				["http://tracker-a.example/announce"],
+				["udp://tracker-b.example:6969"],
+			],
+		});
+		const metadata = fixture.metadata;
+
+		expect(metadata.name).toBe("sample.bin");
+		expect(metadata.totalSize).toBe(12);
+		expect(metadata.pieceLength).toBe(4);
+		expect(metadata.pieceCount).toBe(3);
+		expect(metadata.files).toEqual([
+			{ path: "sample.bin", length: 12, offset: 0 },
+		]);
+		expect(metadata.announceList).toEqual([
+			["http://tracker-a.example/announce"],
+			["udp://tracker-b.example:6969"],
+		]);
+		expect(metadata.formatSize()).toBe("0.0 KB");
+		expect(metadata.formatPieceLength()).toBe("0 KB");
+	});
+
+	test("parses multi-file metadata and maps pieces across file boundaries", () => {
+		const fixture = multiFileTorrentFixture();
+		const metadata = fixture.metadata;
+
+		expect(metadata.name).toBe("album");
+		expect(metadata.totalSize).toBe(12);
+		expect(metadata.pieceLength).toBe(5);
+		expect(metadata.pieceCount).toBe(3);
+		expect(metadata.files).toEqual([
+			{ path: "album/disc1/a.txt", length: 3, offset: 0 },
+			{ path: "album/disc1/b.txt", length: 5, offset: 3 },
+			{ path: "album/c.txt", length: 4, offset: 8 },
+		]);
+		const firstFile = metadata.files[0];
+		const secondFile = metadata.files[1];
+		const thirdFile = metadata.files[2];
+		if (!firstFile || !secondFile || !thirdFile) {
+			throw new Error("missing multi-file metadata fixture entries");
+		}
+
+		expect(metadata.pieceToFileRanges(0)).toEqual([
+			{
+				file: firstFile,
+				fileOffset: 0,
+				length: 3,
+			},
+			{
+				file: secondFile,
+				fileOffset: 0,
+				length: 2,
+			},
+		]);
+		expect(metadata.pieceToFileRanges(2)).toEqual([
+			{
+				file: thirdFile,
+				fileOffset: 2,
+				length: 2,
+			},
+		]);
+	});
+
+	test("throws on invalid metadata", () => {
+		const fixture = singleFileTorrentFixture();
+		const decoded = decode(fixture.raw) as { [key: string]: BencodeValue };
+		const info = decoded.info as { [key: string]: BencodeValue };
+		info.pieces = bytes("bad");
+
+		expect(() => new TorrentMetadata(decoded, encode(decoded))).toThrow(
+			"pieces length is not a multiple of 20",
+		);
+	});
+
+	test("builds metadata from raw fixture bytes", () => {
+		const fixture = singleFileTorrentFixture();
+
+		expect(metadataFromRaw(fixture.raw).name).toBe(fixture.metadata.name);
+	});
+});

--- a/tests/torrent/protocol.test.ts
+++ b/tests/torrent/protocol.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildHandshake,
+	parseHandshake,
+} from "../../src/torrent/peer/handshake.ts";
+import { MessageBuffer } from "../../src/torrent/peer/message-buffer.ts";
+import {
+	decode,
+	decodeHave,
+	decodePiece,
+	decodeRequest,
+	encode,
+	encodeCancel,
+	encodeHave,
+	encodeRequest,
+	MSG,
+	msgName,
+} from "../../src/torrent/peer/protocol.ts";
+import { PiecePicker } from "../../src/torrent/piece-picker.ts";
+import { bytes, concatBytes } from "../helpers/bytes.ts";
+import { FakePeer } from "../helpers/fakes.ts";
+
+describe("peer handshake", () => {
+	test("builds and parses a valid handshake", () => {
+		const infoHash = new Uint8Array(20).fill(1);
+		const peerId = bytes("-TT0001-123456789012");
+		const raw = buildHandshake(infoHash, peerId);
+
+		expect(raw.length).toBe(68);
+		expect(parseHandshake(raw, infoHash)).toEqual({
+			peerId: "-TT0001-123456789012",
+			reserved: new Uint8Array(8),
+		});
+	});
+
+	test("rejects invalid handshakes", () => {
+		const infoHash = new Uint8Array(20).fill(1);
+		const peerId = bytes("-TT0001-123456789012");
+		const raw = buildHandshake(infoHash, peerId);
+		const badProtocol = raw.slice();
+		badProtocol[0] = 18;
+		const badHash = raw.slice();
+		badHash[28] = 2;
+
+		expect(() => parseHandshake(raw.slice(0, 12), infoHash)).toThrow(
+			"Handshake too short",
+		);
+		expect(() => parseHandshake(badProtocol, infoHash)).toThrow(
+			"Invalid pstrlen",
+		);
+		expect(() => parseHandshake(badHash, infoHash)).toThrow(
+			"info_hash mismatch",
+		);
+	});
+});
+
+describe("peer protocol messages", () => {
+	test("encodes and decodes keepalive and simple messages", () => {
+		expect(decode(encode({ type: MSG.KEEPALIVE }))).toEqual({
+			type: MSG.KEEPALIVE,
+		});
+		expect(decode(encode({ type: MSG.CHOKE }))).toEqual({
+			type: MSG.CHOKE,
+			payload: undefined,
+		});
+		expect(decode(encode({ type: MSG.UNCHOKE }))).toEqual({
+			type: MSG.UNCHOKE,
+			payload: undefined,
+		});
+		expect(msgName(MSG.INTERESTED)).toBe("INTERESTED");
+	});
+
+	test("encodes and decodes have, request, cancel, and piece payloads", () => {
+		const have = decode(encodeHave(513));
+		expect(have.type).toBe(MSG.HAVE);
+		expect(decodeHave(have.payload ?? new Uint8Array())).toBe(513);
+
+		const request = decode(encodeRequest(2, 16_384, 8_192));
+		expect(request.type).toBe(MSG.REQUEST);
+		expect(decodeRequest(request.payload ?? new Uint8Array())).toEqual({
+			index: 2,
+			begin: 16_384,
+			length: 8_192,
+		});
+
+		const cancel = decode(encodeCancel(3, 32_768, 4_096));
+		expect(cancel.type).toBe(MSG.CANCEL);
+		expect(decodeRequest(cancel.payload ?? new Uint8Array())).toEqual({
+			index: 3,
+			begin: 32_768,
+			length: 4_096,
+		});
+
+		const block = bytes("payload");
+		const payload = new Uint8Array(8 + block.length);
+		const view = new DataView(payload.buffer);
+		view.setUint32(0, 4);
+		view.setUint32(4, 128);
+		payload.set(block, 8);
+		const piece = decode(encode({ type: MSG.PIECE, payload }));
+		expect(decodePiece(piece.payload ?? new Uint8Array())).toEqual({
+			index: 4,
+			begin: 128,
+			block,
+		});
+	});
+});
+
+describe("MessageBuffer", () => {
+	test("returns complete frames and retains partial trailing data", () => {
+		const buffer = new MessageBuffer();
+		const have = encodeHave(7);
+		const unchoke = encode({ type: MSG.UNCHOKE });
+		const combined = concatBytes([have, unchoke]);
+
+		expect(buffer.push(combined.slice(0, 3))).toEqual([]);
+		expect(buffer.push(combined.slice(3, have.length + 2))).toEqual([have]);
+		expect(buffer.push(combined.slice(have.length + 2))).toEqual([unchoke]);
+	});
+
+	test("handles keepalive and coalesced frames", () => {
+		const buffer = new MessageBuffer();
+		const keepalive = encode({ type: MSG.KEEPALIVE });
+		const interested = encode({ type: MSG.INTERESTED });
+
+		expect(buffer.push(concatBytes([keepalive, interested]))).toEqual([
+			keepalive,
+			interested,
+		]);
+	});
+});
+
+describe("PiecePicker", () => {
+	test("picks the rarest available piece and skips owned or in-progress pieces", () => {
+		const owned = new Set([0]);
+		const inProgress = new Set([2]);
+		const picker = new PiecePicker(
+			5,
+			(index) => owned.has(index),
+			(index) => inProgress.has(index),
+		);
+		const peerA = new FakePeer("127.0.0.1", 6001, new Set([1, 2, 3]));
+		const peerB = new FakePeer("127.0.0.2", 6002, new Set([1, 3, 4]));
+
+		picker.addPeer(peerA.asConnection());
+		picker.addPeer(peerB.asConnection());
+
+		expect(picker.availabilityOf(1)).toBe(2);
+		expect(picker.availabilityOf(4)).toBe(1);
+		expect(picker.pick(peerB.asConnection())).toBe(4);
+
+		picker.removePeer(peerB.asConnection());
+		expect(picker.availabilityOf(1)).toBe(1);
+		expect(picker.availabilityOf(4)).toBe(0);
+	});
+
+	test("tracks have announcements", () => {
+		const picker = new PiecePicker(
+			3,
+			() => false,
+			() => false,
+		);
+		const peer = new FakePeer("127.0.0.1", 6001, new Set([2]));
+
+		picker.onHave(2);
+
+		expect(picker.availabilityOf(2)).toBe(1);
+		expect(picker.pick(peer.asConnection())).toBe(2);
+	});
+});

--- a/tests/torrent/storage-session-downloader.test.ts
+++ b/tests/torrent/storage-session-downloader.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Downloader } from "../../src/torrent/downloader.ts";
+import { TorrentSession } from "../../src/torrent/session.ts";
+import { StorageManager } from "../../src/torrent/storage.ts";
+import { getDataDir } from "../../src/utils/paths.ts";
+import { splitPieces } from "../helpers/bytes.ts";
+import { FakePeer, FakePeerManager } from "../helpers/fakes.ts";
+import { withIsolatedAppData, withTempDir } from "../helpers/temp.ts";
+import {
+	multiFileTorrentFixture,
+	singleFileTorrentFixture,
+} from "../helpers/torrent-fixtures.ts";
+
+describe("StorageManager", () => {
+	test("creates sparse files and verifies missing pieces as absent", async () => {
+		await withTempDir(async (dir) => {
+			const fixture = singleFileTorrentFixture();
+			const storage = new StorageManager(fixture.metadata, dir);
+
+			const setup = await storage.setup();
+			const summary = await storage.verifyAll({ tolerateMissing: true });
+
+			expect(setup).toEqual({
+				createdFiles: 1,
+				existingFiles: 0,
+				allFilesCreated: true,
+			});
+			expect(summary).toEqual({ valid: 0, missing: 3, corrupt: 0 });
+			expect(storage.downloadedCount).toBe(0);
+		});
+	});
+
+	test("writes and reads pieces that cross file boundaries", async () => {
+		await withTempDir(async (dir) => {
+			const fixture = multiFileTorrentFixture();
+			const storage = new StorageManager(fixture.metadata, dir);
+			await storage.setup();
+
+			const pieces = splitPieces(fixture.content, fixture.metadata.pieceLength);
+			for (let i = 0; i < pieces.length; i++) {
+				const piece = pieces[i];
+				if (!piece) throw new Error(`missing fixture piece ${i}`);
+				storage.writePieceSync(i, piece);
+			}
+
+			expect(Buffer.from(storage.readPieceSync(0)).toString()).toBe("abcde");
+			expect(Buffer.from(storage.readPieceSync(1)).toString()).toBe("fghij");
+			expect(Buffer.from(storage.readPieceSync(2)).toString()).toBe("kl");
+			expect(await storage.verifyPiece(1)).toBe(true);
+			expect(storage.downloadedCount).toBe(3);
+		});
+	});
+
+	test("classifies valid, corrupt, and missing pieces", async () => {
+		await withTempDir(async (dir) => {
+			const fixture = singleFileTorrentFixture();
+			const storage = new StorageManager(fixture.metadata, dir);
+			await storage.setup();
+			const pieces = splitPieces(fixture.content, fixture.metadata.pieceLength);
+			const first = pieces[0];
+			if (!first) throw new Error("missing fixture piece");
+
+			storage.writePieceSync(0, first);
+			storage.writePieceSync(1, new Uint8Array([1, 2, 3, 4]));
+
+			const progress: Array<[number, number, number, number]> = [];
+			const summary = await storage.verifyAll({
+				tolerateMissing: true,
+				yieldEveryPieces: 1,
+				yieldEveryMs: 0,
+				onProgress: (checked, valid, missing, corrupt) => {
+					progress.push([checked, valid, missing, corrupt]);
+				},
+			});
+
+			expect(summary).toEqual({ valid: 1, missing: 1, corrupt: 1 });
+			expect(progress.at(-1)).toEqual([3, 1, 1, 1]);
+			expect(storage.downloadedCount).toBe(1);
+			expect(Array.from(storage.getBitfield())).toEqual([0b10000000]);
+		});
+	});
+});
+
+describe("TorrentSession", () => {
+	test("skips verification for newly created sparse files", async () => {
+		await withTempDir(async (dir) => {
+			const fixture = singleFileTorrentFixture();
+			const session = new TorrentSession(fixture.metadata, dir);
+			const statuses: string[] = [];
+			let checkingEvents = 0;
+			session.on("status", (next: string) => statuses.push(next));
+			session.on("checking", () => checkingEvents++);
+
+			await session.startWithOptions();
+
+			expect(statuses).toEqual(["checking", "ready"]);
+			expect(checkingEvents).toBe(0);
+			expect(session.storage.downloadedCount).toBe(0);
+		});
+	});
+
+	test("verifies existing files and emits checking progress", async () => {
+		await withTempDir(async (dir) => {
+			const fixture = singleFileTorrentFixture();
+			const session = new TorrentSession(fixture.metadata, dir);
+			await session.storage.setup();
+			const first = splitPieces(
+				fixture.content,
+				fixture.metadata.pieceLength,
+			)[0];
+			if (!first) throw new Error("missing fixture piece");
+			session.storage.writePieceSync(0, first);
+
+			const events: Array<{ checked: number; total: number; valid: number }> =
+				[];
+			session.on(
+				"checking",
+				(checked: number, total: number, valid: number) => {
+					events.push({ checked, total, valid });
+				},
+			);
+
+			await session.startWithOptions({
+				verifyYieldEveryPieces: 1,
+				verifyYieldEveryMs: 0,
+			});
+
+			expect(events.length).toBe(3);
+			expect(events.at(-1)).toEqual({ checked: 3, total: 3, valid: 1 });
+			expect(session.status).toBe("ready");
+			expect(session.storage.downloadedCount).toBe(1);
+		});
+	});
+});
+
+describe("Downloader", () => {
+	test("pause prevents pipeline fills and resume starts requests", async () => {
+		await withIsolatedAppData(async () => {
+			await withTempDir(async (dir) => {
+				const fixture = singleFileTorrentFixture();
+				const storage = new StorageManager(fixture.metadata, dir);
+				await storage.setup();
+				const peer = new FakePeer("127.0.0.1", 6001, new Set([0, 1, 2]));
+				peer.amChoked = true;
+				const manager = new FakePeerManager([peer]);
+				const downloader = new Downloader(
+					fixture.metadata,
+					storage,
+					manager.asManager(),
+					dir,
+				);
+
+				downloader.start();
+				downloader.pause();
+				peer.amChoked = false;
+				peer.emit("unchoke");
+				expect(peer.requests).toHaveLength(0);
+
+				downloader.resume();
+				expect(peer.requests.length).toBeGreaterThan(0);
+			});
+		});
+	});
+
+	test("downloads all pieces, emits completion, and does not send cancel", async () => {
+		await withIsolatedAppData(async () => {
+			await withTempDir(async (dir) => {
+				const fixture = singleFileTorrentFixture();
+				const storage = new StorageManager(fixture.metadata, dir);
+				await storage.setup();
+				const peer = new FakePeer("127.0.0.1", 6001, new Set([0, 1, 2]));
+				const manager = new FakePeerManager([peer]);
+				const downloader = new Downloader(
+					fixture.metadata,
+					storage,
+					manager.asManager(),
+					dir,
+				);
+				const pieces = splitPieces(
+					fixture.content,
+					fixture.metadata.pieceLength,
+				);
+				let completeCount = 0;
+				const verified: number[] = [];
+				downloader.on("complete", () => completeCount++);
+				downloader.on("piece:verified", (index: number) =>
+					verified.push(index),
+				);
+
+				downloader.start();
+				for (const request of [...peer.requests]) {
+					const piece = pieces[request.index];
+					if (!piece) throw new Error(`missing fixture piece ${request.index}`);
+					peer.emit(
+						"piece",
+						request.index,
+						request.begin,
+						piece.slice(request.begin, request.begin + request.length),
+					);
+				}
+
+				expect(verified).toEqual([0, 1, 2]);
+				expect(completeCount).toBe(1);
+				expect(storage.downloadedCount).toBe(3);
+				expect(peer.cancels).toEqual([]);
+			});
+		});
+	});
+
+	test("stale resume entries do not mark missing pieces as downloaded", async () => {
+		await withIsolatedAppData(async () => {
+			await withTempDir(async (dir) => {
+				const fixture = singleFileTorrentFixture();
+				const storage = new StorageManager(fixture.metadata, dir);
+				await storage.setup();
+				const infoHash = Buffer.from(fixture.metadata.infoHash).toString("hex");
+				const resumeDir = join(getDataDir(), "resume");
+				mkdirSync(resumeDir, { recursive: true });
+				writeFileSync(
+					join(resumeDir, `${infoHash}.json`),
+					JSON.stringify({
+						schemaVersion: 1,
+						infoHash,
+						downloadPath: dir,
+						downloadedPieces: [0, 1, 2],
+						savedAt: 1,
+					}),
+					"utf-8",
+				);
+				const peer = new FakePeer("127.0.0.1", 6001, new Set([0, 1, 2]));
+				const manager = new FakePeerManager([peer]);
+				const downloader = new Downloader(
+					fixture.metadata,
+					storage,
+					manager.asManager(),
+					dir,
+				);
+
+				downloader.start();
+
+				expect(storage.downloadedCount).toBe(0);
+				expect(peer.requests.length).toBeGreaterThan(0);
+			});
+		});
+	});
+});

--- a/tests/torrent/tracker.test.ts
+++ b/tests/torrent/tracker.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { encode } from "../../src/torrent/parser.ts";
+import {
+	parseHTTPCompactPeers,
+	parseHTTPDictionaryPeers,
+	parseHTTPTrackerResponse,
+} from "../../src/torrent/tracker/http-tracker.ts";
+import {
+	parseUDPAnnounceResponse,
+	parseUDPCompactPeers,
+} from "../../src/torrent/tracker/udp-tracker.ts";
+
+describe("HTTP tracker response parsing", () => {
+	test("parses compact IPv4 peers", () => {
+		const peers = parseHTTPCompactPeers(
+			new Uint8Array([127, 0, 0, 1, 0x1a, 0xe1, 10, 0, 0, 2, 0x1a, 0xe2]),
+		);
+
+		expect(peers).toEqual([
+			{ ip: "127.0.0.1", port: 6881 },
+			{ ip: "10.0.0.2", port: 6882 },
+		]);
+	});
+
+	test("parses dictionary peer lists", () => {
+		expect(
+			parseHTTPDictionaryPeers([
+				{ ip: "192.168.1.2", port: 51413 },
+				{ ip: new TextEncoder().encode("2001:db8::1"), port: 6000 },
+				{ ip: "missing-port" },
+			]),
+		).toEqual([
+			{ ip: "192.168.1.2", port: 51413 },
+			{ ip: "2001:db8::1", port: 6000 },
+		]);
+	});
+
+	test("parses full tracker responses", () => {
+		const response = encode({
+			interval: 1800,
+			peers: new Uint8Array([1, 2, 3, 4, 0x1a, 0xe1]),
+		});
+
+		expect(parseHTTPTrackerResponse(response)).toEqual([
+			{ ip: "1.2.3.4", port: 6881 },
+		]);
+	});
+
+	test("throws tracker failures and ignores malformed compact payloads", () => {
+		expect(() =>
+			parseHTTPTrackerResponse(encode({ "failure reason": "bad torrent" })),
+		).toThrow("Tracker failure: bad torrent");
+
+		expect(parseHTTPCompactPeers(new Uint8Array([1, 2, 3]))).toEqual([]);
+	});
+});
+
+describe("UDP tracker response parsing", () => {
+	test("parses compact peers", () => {
+		expect(
+			parseUDPCompactPeers(
+				new Uint8Array([8, 8, 8, 8, 0x1a, 0xe1, 9, 9, 9, 9, 0x1a, 0xe2]),
+				0,
+			),
+		).toEqual([
+			{ ip: "8.8.8.8", port: 6881 },
+			{ ip: "9.9.9.9", port: 6882 },
+		]);
+	});
+
+	test("parses announce responses", () => {
+		const txId = 0x12345678;
+		const response = buildAnnounceResponse(txId, [127, 0, 0, 1, 0x1a, 0xe1]);
+
+		expect(parseUDPAnnounceResponse(response, txId)).toEqual({
+			complete: 7,
+			incomplete: 3,
+			interval: 900,
+			peers: [{ ip: "127.0.0.1", port: 6881 }],
+		});
+	});
+
+	test("rejects malformed announce responses", () => {
+		const txId = 0x12345678;
+		const response = buildAnnounceResponse(txId, []);
+		const badAction = response.slice();
+		new DataView(
+			badAction.buffer,
+			badAction.byteOffset,
+			badAction.byteLength,
+		).setInt32(0, 2);
+
+		expect(() => parseUDPAnnounceResponse(response.slice(0, 12), txId)).toThrow(
+			"too short",
+		);
+		expect(() => parseUDPAnnounceResponse(badAction, txId)).toThrow(
+			"bad announce action",
+		);
+		expect(() => parseUDPAnnounceResponse(response, 1)).toThrow(
+			"announce txId mismatch",
+		);
+		expect(() => parseUDPCompactPeers(new Uint8Array([1, 2, 3]), 0)).toThrow(
+			"Invalid UDP compact peer data",
+		);
+	});
+});
+
+function buildAnnounceResponse(txId: number, peerBytes: number[]): Uint8Array {
+	const buf = new Uint8Array(20 + peerBytes.length);
+	const view = new DataView(buf.buffer);
+	view.setInt32(0, 1);
+	view.setUint32(4, txId);
+	view.setInt32(8, 900);
+	view.setInt32(12, 3);
+	view.setInt32(16, 7);
+	buf.set(peerBytes, 20);
+	return buf;
+}


### PR DESCRIPTION
## Summary
- Add Bun-based engine regression fixtures for parser, metadata, protocol, storage, session, and downloader behavior
- Extract tracker response parsing into pure helpers and cover HTTP/UDP fixtures offline
- Wire tests into release checks and update project metadata ignores

## Verification
- bun test
- bun run typecheck
- bun run smoke