### PR TITLE
Add trusted resume data with chunked verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
 		"dev": "bun --watch src/index.ts",
 		"check": "bun src/index.ts --download",
 		"smoke": "bin/torrent-tui --help && bin/torrent-tui --version && if bin/torrent-tui nope.txt; then echo \"Expected invalid torrent path to fail\"; exit 1; fi",
+		"bench:startup": "bun scripts/benchmark-startup.ts",
+		"bench:verify": "bun scripts/benchmark-verify.ts",
 		"test": "bun test",
 		"test:watch": "bun test --watch",
 		"typecheck": "tsc --noEmit",

--- a/scripts/benchmark-startup.ts
+++ b/scripts/benchmark-startup.ts
@@ -105,26 +105,33 @@ async function runRound(args: Args): Promise<Record<string, number>> {
 			}
 		});
 
-		await bridge.restoreSession();
-		const restoreReturnMs = performance.now() - started;
-		await waitFor(() => backgroundCompleteMs !== null || !args.stale, 30_000);
-		if (backgroundCompleteMs === null) backgroundCompleteMs = restoreReturnMs;
+		try {
+			await bridge.restoreSession();
+			const restoreReturnMs = performance.now() - started;
+			await waitFor(() => backgroundCompleteMs !== null || !args.stale, 30_000);
+			if (backgroundCompleteMs === null && args.stale) {
+				console.warn("warning: background verification timed out");
+			}
 
-		const cpu = process.cpuUsage(cpuStart);
-		const peaks = sampler.stop();
-		const maxEventLoopDelayMs = loopDelay.stop();
+			const cpu = process.cpuUsage(cpuStart);
+			const peaks = sampler.stop();
+			const maxEventLoopDelayMs = loopDelay.stop();
 
-		return {
-			firstRowMs: firstRowMs ?? restoreReturnMs,
-			allRowsMs: allRowsMs ?? restoreReturnMs,
-			restoreReturnMs,
-			backgroundCompleteMs,
-			cpuUserMs: cpu.user / 1000,
-			cpuSystemMs: cpu.system / 1000,
-			peakRssMiB: peaks.rss / MIB,
-			peakHeapMiB: peaks.heapUsed / MIB,
-			maxEventLoopDelayMs,
-		};
+			return {
+				firstRowMs: firstRowMs ?? restoreReturnMs,
+				allRowsMs: allRowsMs ?? restoreReturnMs,
+				restoreReturnMs,
+				backgroundCompleteMs: backgroundCompleteMs ?? restoreReturnMs,
+				cpuUserMs: cpu.user / 1000,
+				cpuSystemMs: cpu.system / 1000,
+				peakRssMiB: peaks.rss / MIB,
+				peakHeapMiB: peaks.heapUsed / MIB,
+				maxEventLoopDelayMs,
+			};
+		} finally {
+			sampler.stop();
+			loopDelay.stop();
+		}
 	} finally {
 		restoreEnv("HOME", previousHome);
 		restoreEnv("XDG_DATA_HOME", previousXdgDataHome);
@@ -309,7 +316,11 @@ function parseArgs(args: string[]): Args {
 	const parsed: Args = { rounds: 3, stale: false };
 	for (const arg of args) {
 		if (arg.startsWith("--rounds=")) {
-			parsed.rounds = Number(arg.slice("--rounds=".length));
+			const n = Math.floor(Number(arg.slice("--rounds=".length)));
+			if (!Number.isInteger(n) || n <= 0) {
+				throw new Error("--rounds must be a positive integer");
+			}
+			parsed.rounds = n;
 			continue;
 		}
 		if (arg === "--stale") {

--- a/scripts/benchmark-startup.ts
+++ b/scripts/benchmark-startup.ts
@@ -1,0 +1,343 @@
+import {
+	closeSync,
+	ftruncateSync,
+	mkdirSync,
+	mkdtempSync,
+	openSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { Store } from "../src/store/index.ts";
+import { TorrentBridge } from "../src/torrent/bridge.ts";
+import { TorrentMetadata } from "../src/torrent/metadata.ts";
+import type { BencodeValue } from "../src/torrent/parser.ts";
+import { encode } from "../src/torrent/parser.ts";
+import { writeResumeData } from "../src/torrent/resume.ts";
+
+interface ScenarioTorrent {
+	completePieces: number;
+	name: string;
+	pieces: number;
+}
+
+interface Args {
+	rounds: number;
+	stale: boolean;
+}
+
+const MIB = 1024 * 1024;
+const DEFAULT_PIECE_LENGTH = MIB;
+const USER_SCENARIO: ScenarioTorrent[] = [
+	{ name: "seeded-1-8g.bin", pieces: 1844, completePieces: 1844 },
+	{ name: "stopped-1-4g.bin", pieces: 1434, completePieces: 57 },
+];
+
+async function main(): Promise<void> {
+	const args = parseArgs(process.argv.slice(2));
+	const results = [];
+
+	for (let round = 0; round < args.rounds; round++) {
+		results.push(await runRound(args));
+	}
+
+	const summary = summarize(results);
+	console.log(JSON.stringify(summary, null, 2));
+}
+
+async function runRound(args: Args): Promise<Record<string, number>> {
+	const dir = mkdtempSync(join(tmpdir(), "torrent-tui-startup-bench-"));
+	const previousHome = process.env.HOME;
+	const previousXdgDataHome = process.env.XDG_DATA_HOME;
+	const previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
+
+	try {
+		const paths = {
+			home: join(dir, "home"),
+			data: join(dir, "data"),
+			config: join(dir, "config"),
+			downloads: join(dir, "downloads"),
+			torrents: join(dir, "torrents"),
+		};
+		process.env.HOME = paths.home;
+		process.env.XDG_DATA_HOME = paths.data;
+		process.env.XDG_CONFIG_HOME = paths.config;
+
+		const fixture = createScenario(paths.downloads, paths.torrents, args.stale);
+		const store = new Store({
+			selectedIndex: 0,
+			selectedView: "All",
+			torrents: [],
+			totalDownloadBps: 0,
+			totalUploadBps: 0,
+		});
+		const bridge = new TorrentBridge(store, {
+			downloadPath: paths.downloads,
+			maxConnections: 50,
+			torrentFolder: paths.torrents,
+		});
+
+		let firstRowMs: number | null = null;
+		let allRowsMs: number | null = null;
+		let backgroundCompleteMs: number | null = null;
+		const started = performance.now();
+		const cpuStart = process.cpuUsage();
+		const sampler = createSampler();
+		const loopDelay = createEventLoopDelayMonitor();
+		sampler.start();
+		loopDelay.start();
+
+		store.subscribe((state) => {
+			const elapsed = performance.now() - started;
+			if (firstRowMs === null && state.torrents.length > 0)
+				firstRowMs = elapsed;
+			if (allRowsMs === null && state.torrents.length === fixture.count) {
+				allRowsMs = elapsed;
+			}
+			if (
+				backgroundCompleteMs === null &&
+				state.torrents.length === fixture.count &&
+				state.torrents.every((torrent) => torrent.status !== "checking")
+			) {
+				backgroundCompleteMs = elapsed;
+			}
+		});
+
+		await bridge.restoreSession();
+		const restoreReturnMs = performance.now() - started;
+		await waitFor(() => backgroundCompleteMs !== null || !args.stale, 30_000);
+		if (backgroundCompleteMs === null) backgroundCompleteMs = restoreReturnMs;
+
+		const cpu = process.cpuUsage(cpuStart);
+		const peaks = sampler.stop();
+		const maxEventLoopDelayMs = loopDelay.stop();
+
+		return {
+			firstRowMs: firstRowMs ?? restoreReturnMs,
+			allRowsMs: allRowsMs ?? restoreReturnMs,
+			restoreReturnMs,
+			backgroundCompleteMs,
+			cpuUserMs: cpu.user / 1000,
+			cpuSystemMs: cpu.system / 1000,
+			peakRssMiB: peaks.rss / MIB,
+			peakHeapMiB: peaks.heapUsed / MIB,
+			maxEventLoopDelayMs,
+		};
+	} finally {
+		restoreEnv("HOME", previousHome);
+		restoreEnv("XDG_DATA_HOME", previousXdgDataHome);
+		restoreEnv("XDG_CONFIG_HOME", previousXdgConfigHome);
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+function createScenario(
+	downloadPath: string,
+	torrentPath: string,
+	stale: boolean,
+): { count: number } {
+	const registry: Array<{ infoHash: string; torrentPath: string }> = [];
+	mkdirSync(downloadPath, { recursive: true });
+	mkdirSync(torrentPath, { recursive: true });
+
+	for (const torrent of USER_SCENARIO) {
+		const metadata = createTorrent(downloadPath, torrentPath, torrent);
+		if (!stale) {
+			writeResumeData(metadata, downloadPath, range(0, torrent.completePieces));
+		}
+		registry.push({
+			infoHash: Buffer.from(metadata.infoHash).toString("hex"),
+			torrentPath: join(torrentPath, `${torrent.name}.torrent`),
+		});
+	}
+
+	const registryFile = join(
+		process.env.XDG_DATA_HOME ?? "",
+		"torrent-tui",
+		"session.json",
+	);
+	mkdirSync(join(process.env.XDG_DATA_HOME ?? "", "torrent-tui"), {
+		recursive: true,
+	});
+	writeFileSync(
+		registryFile,
+		JSON.stringify({ schemaVersion: 1, torrents: registry }),
+	);
+	return { count: USER_SCENARIO.length };
+}
+
+function createTorrent(
+	downloadPath: string,
+	torrentPath: string,
+	torrent: ScenarioTorrent,
+): TorrentMetadata {
+	const fullPath = join(downloadPath, torrent.name);
+	const fd = openSync(fullPath, "w");
+	try {
+		ftruncateSync(fd, torrent.pieces * DEFAULT_PIECE_LENGTH);
+	} finally {
+		closeSync(fd);
+	}
+
+	const pieces: Uint8Array[] = [];
+	for (let i = 0; i < torrent.pieces; i++) {
+		pieces.push(fakePieceHash(i));
+	}
+	const info: { [key: string]: BencodeValue } = {
+		length: torrent.pieces * DEFAULT_PIECE_LENGTH,
+		name: torrent.name,
+		"piece length": DEFAULT_PIECE_LENGTH,
+		pieces: concatBytes(pieces),
+	};
+	const decoded = { announce: "http://tracker.example/announce", info };
+	const raw = encode(decoded);
+	const metadata = new TorrentMetadata(decoded, raw);
+	writeFileSync(join(torrentPath, `${torrent.name}.torrent`), raw);
+	return metadata;
+}
+
+function fakePieceHash(piece: number): Uint8Array {
+	const bytes = new Uint8Array(20);
+	for (let i = 0; i < bytes.length; i++) {
+		bytes[i] = (piece * 31 + i * 17) & 0xff;
+	}
+	return bytes;
+}
+
+function concatBytes(parts: Uint8Array[]): Uint8Array {
+	const total = parts.reduce((sum, part) => sum + part.length, 0);
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const part of parts) {
+		out.set(part, offset);
+		offset += part.length;
+	}
+	return out;
+}
+
+function createSampler(): {
+	start: () => void;
+	stop: () => { heapUsed: number; rss: number };
+} {
+	let timer: ReturnType<typeof setInterval> | null = null;
+	let rss = 0;
+	let heapUsed = 0;
+
+	const sample = (): void => {
+		const memory = process.memoryUsage();
+		rss = Math.max(rss, memory.rss);
+		heapUsed = Math.max(heapUsed, memory.heapUsed);
+	};
+
+	return {
+		start: () => {
+			sample();
+			timer = setInterval(sample, 5);
+		},
+		stop: () => {
+			if (timer) clearInterval(timer);
+			sample();
+			return { heapUsed, rss };
+		},
+	};
+}
+
+function createEventLoopDelayMonitor(intervalMs = 10): {
+	start: () => void;
+	stop: () => number;
+} {
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let expected = 0;
+	let maxDelay = 0;
+
+	const tick = (): void => {
+		const now = performance.now();
+		maxDelay = Math.max(maxDelay, Math.max(0, now - expected));
+		expected = now + intervalMs;
+		timer = setTimeout(tick, intervalMs);
+	};
+
+	return {
+		start: () => {
+			expected = performance.now() + intervalMs;
+			timer = setTimeout(tick, intervalMs);
+		},
+		stop: () => {
+			if (timer) clearTimeout(timer);
+			return maxDelay;
+		},
+	};
+}
+
+function summarize(
+	results: Array<Record<string, number>>,
+): Record<string, unknown> {
+	const averages: Record<string, number> = {};
+	for (const key of Object.keys(results[0] ?? {})) {
+		averages[key] = average(results.map((result) => result[key] ?? 0));
+	}
+	return {
+		scenario: "1.8GiB complete + 1.4GiB 4% stopped",
+		rounds: results.length,
+		results: results.map(roundValues),
+		average: roundValues(averages),
+	};
+}
+
+function roundValues(values: Record<string, number>): Record<string, number> {
+	return Object.fromEntries(
+		Object.entries(values).map(([key, value]) => [
+			key,
+			Number(value.toFixed(1)),
+		]),
+	);
+}
+
+function average(values: number[]): number {
+	return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function range(start: number, end: number): number[] {
+	const values: number[] = [];
+	for (let i = start; i < end; i++) values.push(i);
+	return values;
+}
+
+function parseArgs(args: string[]): Args {
+	const parsed: Args = { rounds: 3, stale: false };
+	for (const arg of args) {
+		if (arg.startsWith("--rounds=")) {
+			parsed.rounds = Number(arg.slice("--rounds=".length));
+			continue;
+		}
+		if (arg === "--stale") {
+			parsed.stale = true;
+			continue;
+		}
+		throw new Error(`Unknown argument ${arg}`);
+	}
+	return parsed;
+}
+
+async function waitFor(fn: () => boolean, timeoutMs: number): Promise<void> {
+	const started = Date.now();
+	while (!fn()) {
+		if (Date.now() - started > timeoutMs) return;
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[name];
+		return;
+	}
+	process.env[name] = value;
+}
+
+main().catch((err: unknown) => {
+	console.error(err instanceof Error ? err.message : String(err));
+	process.exitCode = 1;
+});

--- a/scripts/benchmark-verify.ts
+++ b/scripts/benchmark-verify.ts
@@ -1,0 +1,269 @@
+import { closeSync, mkdtempSync, openSync, rmSync, writeSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { SHA1 } from "bun";
+import { TorrentMetadata } from "../src/torrent/metadata.ts";
+import type { BencodeValue } from "../src/torrent/parser.ts";
+import { encode } from "../src/torrent/parser.ts";
+import { StorageManager } from "../src/torrent/storage.ts";
+
+interface BenchmarkProfile {
+	name: string;
+	pieces: number;
+	pieceLength: number;
+}
+
+interface BenchmarkArgs {
+	profiles: BenchmarkProfile[];
+	chunkSizeBytes?: number;
+}
+
+const KIB = 1024;
+const MIB = 1024 * KIB;
+const PROFILES: Record<string, BenchmarkProfile> = {
+	small: { name: "small", pieces: 64, pieceLength: 256 * KIB },
+	medium: { name: "medium", pieces: 128, pieceLength: MIB },
+	large: { name: "large", pieces: 256, pieceLength: 4 * MIB },
+};
+
+async function main(): Promise<void> {
+	const args = parseArgs(process.argv.slice(2));
+	for (const profile of args.profiles) {
+		await runProfile(profile, args.chunkSizeBytes);
+	}
+}
+
+async function runProfile(
+	profile: BenchmarkProfile,
+	chunkSizeBytes: number | undefined,
+): Promise<void> {
+	const dir = mkdtempSync(join(tmpdir(), "torrent-tui-verify-bench-"));
+	const totalBytes = profile.pieces * profile.pieceLength;
+	try {
+		const { metadata } = createFixture(dir, profile);
+		const storage = new StorageManager(metadata, dir);
+		const loopDelay = createEventLoopDelayMonitor();
+
+		loopDelay.start();
+		const started = performance.now();
+		const summary = await storage.verifyAll({
+			chunkSizeBytes,
+			yieldEveryPieces: 1,
+			yieldEveryMs: 8,
+		});
+		const elapsedMs = performance.now() - started;
+		const maxEventLoopDelayMs = loopDelay.stop();
+		const seconds = elapsedMs / 1000;
+
+		console.log("");
+		console.log(`verify benchmark: ${profile.name}`);
+		console.log(`  pieces                ${profile.pieces}`);
+		console.log(`  piece length          ${formatBytes(profile.pieceLength)}`);
+		console.log(`  total size            ${formatBytes(totalBytes)}`);
+		console.log(`  elapsed ms            ${elapsedMs.toFixed(1)}`);
+		console.log(
+			`  pieces/sec            ${(profile.pieces / seconds).toFixed(2)}`,
+		);
+		console.log(
+			`  MiB/sec               ${(totalBytes / MIB / seconds).toFixed(2)}`,
+		);
+		console.log(`  max event-loop delay  ${maxEventLoopDelayMs.toFixed(1)} ms`);
+		console.log(
+			`  result                ${summary.valid} valid, ${summary.missing} missing, ${summary.corrupt} corrupt`,
+		);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+function createFixture(
+	dir: string,
+	profile: BenchmarkProfile,
+): { metadata: TorrentMetadata } {
+	const fileName = `${profile.name}.bin`;
+	const filePath = join(dir, fileName);
+	const fd = openSync(filePath, "w");
+	const hashes: Uint8Array[] = [];
+
+	try {
+		for (let i = 0; i < profile.pieces; i++) {
+			const piece = deterministicPiece(i, profile.pieceLength);
+			hashes.push(new SHA1().update(piece).digest() as unknown as Uint8Array);
+			writeSync(fd, piece, 0, piece.length);
+		}
+	} finally {
+		closeSync(fd);
+	}
+
+	const info: { [key: string]: BencodeValue } = {
+		length: profile.pieces * profile.pieceLength,
+		name: fileName,
+		"piece length": profile.pieceLength,
+		pieces: concatBytes(hashes),
+	};
+	const raw = encode({
+		announce: "http://tracker.example/announce",
+		info,
+	});
+	return {
+		metadata: new TorrentMetadata(
+			{ announce: "http://tracker.example/announce", info },
+			raw,
+		),
+	};
+}
+
+function deterministicPiece(index: number, length: number): Buffer {
+	const piece = Buffer.allocUnsafe(length);
+	for (let i = 0; i < piece.length; i++) {
+		piece[i] = ((index + 1) * 31 + i * 17) & 0xff;
+	}
+	return piece;
+}
+
+function concatBytes(parts: Uint8Array[]): Uint8Array {
+	const total = parts.reduce((sum, part) => sum + part.length, 0);
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const part of parts) {
+		out.set(part, offset);
+		offset += part.length;
+	}
+	return out;
+}
+
+function createEventLoopDelayMonitor(intervalMs = 10): {
+	start: () => void;
+	stop: () => number;
+} {
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let expected = 0;
+	let maxDelay = 0;
+
+	const tick = (): void => {
+		const now = performance.now();
+		maxDelay = Math.max(maxDelay, Math.max(0, now - expected));
+		expected = now + intervalMs;
+		timer = setTimeout(tick, intervalMs);
+	};
+
+	return {
+		start: () => {
+			expected = performance.now() + intervalMs;
+			timer = setTimeout(tick, intervalMs);
+		},
+		stop: () => {
+			if (timer !== null) clearTimeout(timer);
+			return maxDelay;
+		},
+	};
+}
+
+function parseArgs(args: string[]): BenchmarkArgs {
+	let profiles: BenchmarkProfile[] = [
+		profileFor("small"),
+		profileFor("medium"),
+	];
+	let chunkSizeBytes: number | undefined;
+
+	for (const arg of args) {
+		if (arg === "--all") {
+			profiles = [
+				profileFor("small"),
+				profileFor("medium"),
+				profileFor("large"),
+			];
+			continue;
+		}
+		if (arg.startsWith("--profile=")) {
+			const profileName = arg.slice("--profile=".length);
+			profiles = [profileFor(profileName)];
+			continue;
+		}
+		if (arg.startsWith("--pieces=")) {
+			const pieces = parsePositiveInt(arg.slice("--pieces=".length), "pieces");
+			const base = profiles[0] ?? profileFor("small");
+			profiles = [{ ...base, name: "custom", pieces }];
+			continue;
+		}
+		if (arg.startsWith("--piece-length=")) {
+			const pieceLength = parseSize(arg.slice("--piece-length=".length));
+			const base = profiles[0] ?? profileFor("small");
+			profiles = [{ ...base, name: "custom", pieceLength }];
+			continue;
+		}
+		if (arg.startsWith("--chunk-size=")) {
+			chunkSizeBytes = parseSize(arg.slice("--chunk-size=".length));
+			continue;
+		}
+		if (arg === "--help" || arg === "-h") {
+			printHelp();
+			process.exitCode = 0;
+			return { profiles: [] };
+		}
+		throw new Error(`Unknown argument '${arg}'`);
+	}
+
+	return {
+		profiles: profiles.filter(
+			(profile): profile is BenchmarkProfile => !!profile,
+		),
+		chunkSizeBytes,
+	};
+}
+
+function profileFor(name: string): BenchmarkProfile {
+	const profile = PROFILES[name];
+	if (!profile) {
+		throw new Error(
+			`Unknown profile '${name}'. Use small, medium, large, or --all.`,
+		);
+	}
+	return profile;
+}
+
+function parsePositiveInt(value: string, label: string): number {
+	const parsed = Number(value);
+	if (!Number.isInteger(parsed) || parsed <= 0) {
+		throw new Error(`${label} must be a positive integer`);
+	}
+	return parsed;
+}
+
+function parseSize(value: string): number {
+	const match = /^(\d+)(kib|kb|mib|mb|b)?$/i.exec(value);
+	if (!match) {
+		throw new Error(`Invalid size '${value}'`);
+	}
+	const amount = parsePositiveInt(match[1] ?? "", "size");
+	const unit = (match[2] ?? "b").toLowerCase();
+	if (unit === "kib" || unit === "kb") return amount * KIB;
+	if (unit === "mib" || unit === "mb") return amount * MIB;
+	return amount;
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes >= MIB) return `${(bytes / MIB).toFixed(1)} MiB`;
+	if (bytes >= KIB) return `${(bytes / KIB).toFixed(1)} KiB`;
+	return `${bytes} B`;
+}
+
+function printHelp(): void {
+	console.log(`Usage: bun run bench:verify [options]
+
+Options:
+  --profile=small|medium|large   Run one built-in profile
+  --all                          Run every built-in profile
+  --pieces=N                     Run a custom piece count
+  --piece-length=SIZE            Run a custom piece length, e.g. 512KiB or 4MiB
+  --chunk-size=SIZE              Override verifier chunk size
+  --help, -h                     Show this help`);
+}
+
+main().catch((err: unknown) => {
+	console.error(
+		`benchmark failed: ${err instanceof Error ? err.message : err}`,
+	);
+	process.exitCode = 1;
+});

--- a/scripts/benchmark-verify.ts
+++ b/scripts/benchmark-verify.ts
@@ -44,16 +44,22 @@ async function runProfile(
 		const { metadata } = createFixture(dir, profile);
 		const storage = new StorageManager(metadata, dir);
 		const loopDelay = createEventLoopDelayMonitor();
+		let elapsedMs = 0;
+		let maxEventLoopDelayMs = 0;
 
 		loopDelay.start();
 		const started = performance.now();
-		const summary = await storage.verifyAll({
-			chunkSizeBytes,
-			yieldEveryPieces: 1,
-			yieldEveryMs: 8,
-		});
-		const elapsedMs = performance.now() - started;
-		const maxEventLoopDelayMs = loopDelay.stop();
+		let summary: Awaited<ReturnType<typeof storage.verifyAll>>;
+		try {
+			summary = await storage.verifyAll({
+				chunkSizeBytes,
+				yieldEveryPieces: 1,
+				yieldEveryMs: 8,
+			});
+		} finally {
+			elapsedMs = performance.now() - started;
+			maxEventLoopDelayMs = loopDelay.stop();
+		}
 		const seconds = elapsedMs / 1000;
 
 		console.log("");

--- a/src/app.ts
+++ b/src/app.ts
@@ -114,7 +114,6 @@ export class App {
 
 		await this.bridge.restoreSession();
 		this.controller.start();
-		void this.bridge.verifyTrustedRestores();
 
 		if (initialTorrentPath) {
 			const filename =

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,9 +1,9 @@
 // Config loader - reads from ~/.config/torrent-tui/settings.json
 
 import { existsSync, readFileSync } from "node:fs";
-import { getConfigPath } from "../utils/paths";
-import { writeJsonAtomic } from "../utils/json";
 import { log } from "../torrent/metadata";
+import { writeJsonAtomic } from "../utils/json";
+import { getConfigPath } from "../utils/paths";
 import { type AppSettings, DEFAULT_SETTINGS, settingsSchema } from "./settings";
 
 const SETTINGS_FILE = "settings.json";

--- a/src/controllers/app-controller.ts
+++ b/src/controllers/app-controller.ts
@@ -319,7 +319,8 @@ export class AppController {
 				} else if (
 					torrent.status === "stopped" ||
 					torrent.status === "stalled" ||
-					torrent.status === "error"
+					torrent.status === "error" ||
+					torrent.status === "missing"
 				) {
 					this.runTorrentAction("start torrent", () =>
 						this.onStartTorrent?.(id),

--- a/src/layout/add-torrent-dialog.ts
+++ b/src/layout/add-torrent-dialog.ts
@@ -1,22 +1,23 @@
-import { readdirSync, existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { BoxRenderable, type CliRenderer, TextRenderable } from "@opentui/core";
 import { getTheme } from "../theme";
 import type { LayoutDimensions } from "../types/layout";
 import { resolvePath } from "../utils/paths";
 
-const DIALOG_WIDTH  = 60;
+const DIALOG_WIDTH = 60;
 const DIALOG_HEIGHT = 16;
-const INNER_W       = DIALOG_WIDTH - 2;
-const MARGIN        = 2;
+const INNER_W = DIALOG_WIDTH - 2;
+const MARGIN = 2;
 
 function truncateName(name: string): string {
 	const max = INNER_W - MARGIN * 2;
-	return name.length > max ? name.slice(0, max - 1) + "…" : name;
+	return name.length > max ? `${name.slice(0, max - 1)}…` : name;
 }
 
 function setBg(node: BoxRenderable, bg: string | undefined): void {
-	(node as unknown as { backgroundColor: string | undefined }).backgroundColor = bg;
+	(node as unknown as { backgroundColor: string | undefined }).backgroundColor =
+		bg;
 }
 
 export class AddTorrentDialog {
@@ -31,7 +32,11 @@ export class AddTorrentDialog {
 
 	onSelect?: (filePath: string) => void;
 
-	constructor(renderer: CliRenderer, layout: LayoutDimensions, torrentFolder: string) {
+	constructor(
+		renderer: CliRenderer,
+		layout: LayoutDimensions,
+		torrentFolder: string,
+	) {
 		this.renderer = renderer;
 		this.layout = layout;
 		this.torrentFolder = resolvePath(torrentFolder);
@@ -93,14 +98,23 @@ export class AddTorrentDialog {
 	private updateHighlight(): void {
 		const theme = getTheme();
 		for (let i = 0; i < this.itemRows.length; i++) {
-			setBg(this.itemRows[i]!, i === this.selectedIndex ? theme.bgTertiary : undefined);
+			setBg(
+				this.itemRows[i]!,
+				i === this.selectedIndex ? theme.bgTertiary : undefined,
+			);
 		}
 	}
 
 	private build(): void {
 		const theme = getTheme();
-		const left = Math.max(0, Math.floor((this.layout.terminal.width  - DIALOG_WIDTH)  / 2));
-		const top  = Math.max(0, Math.floor((this.layout.terminal.height - DIALOG_HEIGHT) / 2));
+		const left = Math.max(
+			0,
+			Math.floor((this.layout.terminal.width - DIALOG_WIDTH) / 2),
+		);
+		const top = Math.max(
+			0,
+			Math.floor((this.layout.terminal.height - DIALOG_HEIGHT) / 2),
+		);
 
 		const container = new BoxRenderable(this.renderer, {
 			position: "absolute",
@@ -122,8 +136,18 @@ export class AddTorrentDialog {
 			paddingLeft: MARGIN,
 			paddingRight: MARGIN,
 		});
-		titleRow.add(new TextRenderable(this.renderer, { content: "Add Torrent", fg: theme.accent }));
-		titleRow.add(new TextRenderable(this.renderer, { content: "Esc to close", fg: theme.fgMuted }));
+		titleRow.add(
+			new TextRenderable(this.renderer, {
+				content: "Add Torrent",
+				fg: theme.accent,
+			}),
+		);
+		titleRow.add(
+			new TextRenderable(this.renderer, {
+				content: "Esc to close",
+				fg: theme.fgMuted,
+			}),
+		);
 		container.add(titleRow);
 
 		// Spacer
@@ -132,22 +156,27 @@ export class AddTorrentDialog {
 		this.itemRows = [];
 
 		if (this.files.length === 0) {
-			container.add(new TextRenderable(this.renderer, {
-				content: " ".repeat(MARGIN) + `No .torrent files in ${this.torrentFolder}`,
-				fg: theme.fgMuted,
-			}));
+			container.add(
+				new TextRenderable(this.renderer, {
+					content: `${" ".repeat(MARGIN)}No .torrent files in ${this.torrentFolder}`,
+					fg: theme.fgMuted,
+				}),
+			);
 		} else {
 			for (let i = 0; i < this.files.length; i++) {
 				const file = this.files[i]!;
 				const row = new BoxRenderable(this.renderer, {
 					width: INNER_W,
 					height: 1,
-					backgroundColor: i === this.selectedIndex ? theme.bgTertiary : undefined,
+					backgroundColor:
+						i === this.selectedIndex ? theme.bgTertiary : undefined,
 				});
-				row.add(new TextRenderable(this.renderer, {
-					content: " ".repeat(MARGIN) + truncateName(file.name),
-					fg: i === this.selectedIndex ? theme.fgPrimary : theme.fgSecondary,
-				}));
+				row.add(
+					new TextRenderable(this.renderer, {
+						content: " ".repeat(MARGIN) + truncateName(file.name),
+						fg: i === this.selectedIndex ? theme.fgPrimary : theme.fgSecondary,
+					}),
+				);
 				container.add(row);
 				this.itemRows.push(row);
 			}

--- a/src/layout/confirm-dialog.ts
+++ b/src/layout/confirm-dialog.ts
@@ -2,7 +2,7 @@ import { BoxRenderable, type CliRenderer, TextRenderable } from "@opentui/core";
 import { getTheme } from "../theme";
 import type { LayoutDimensions } from "../types/layout";
 
-const DIALOG_WIDTH  = 38;
+const DIALOG_WIDTH = 38;
 const DIALOG_HEIGHT = 7;
 
 export class ConfirmDialog {
@@ -44,7 +44,13 @@ export class ConfirmDialog {
 
 	handleInput(key: string): boolean {
 		if (!this.isOpen) return false;
-		if (key === "tab" || key === "h" || key === "l" || key === "left" || key === "right") {
+		if (
+			key === "tab" ||
+			key === "h" ||
+			key === "l" ||
+			key === "left" ||
+			key === "right"
+		) {
 			this.focusedBtn = this.focusedBtn === "confirm" ? "cancel" : "confirm";
 			this.updateButtons();
 			return true;
@@ -85,8 +91,14 @@ export class ConfirmDialog {
 
 	private build(message: string): void {
 		const theme = getTheme();
-		const left = Math.max(0, Math.floor((this.layout.terminal.width  - DIALOG_WIDTH)  / 2));
-		const top  = Math.max(0, Math.floor((this.layout.terminal.height - DIALOG_HEIGHT) / 2));
+		const left = Math.max(
+			0,
+			Math.floor((this.layout.terminal.width - DIALOG_WIDTH) / 2),
+		);
+		const top = Math.max(
+			0,
+			Math.floor((this.layout.terminal.height - DIALOG_HEIGHT) / 2),
+		);
 
 		const container = new BoxRenderable(this.renderer, {
 			position: "absolute",
@@ -101,17 +113,27 @@ export class ConfirmDialog {
 
 		const inner = DIALOG_WIDTH - 2;
 
-		container.add(new TextRenderable(this.renderer, { content: " ".repeat(inner) }));
-		container.add(new TextRenderable(this.renderer, {
-			content: ("  " + message).padEnd(inner),
-			fg: theme.fgPrimary,
-		}));
-		container.add(new TextRenderable(this.renderer, { content: " ".repeat(inner) }));
-		container.add(new TextRenderable(this.renderer, {
-			content: "  Files will be deleted from disk.".padEnd(inner),
-			fg: theme.fgSecondary,
-		}));
-		container.add(new TextRenderable(this.renderer, { content: " ".repeat(inner) }));
+		container.add(
+			new TextRenderable(this.renderer, { content: " ".repeat(inner) }),
+		);
+		container.add(
+			new TextRenderable(this.renderer, {
+				content: `  ${message}`.padEnd(inner),
+				fg: theme.fgPrimary,
+			}),
+		);
+		container.add(
+			new TextRenderable(this.renderer, { content: " ".repeat(inner) }),
+		);
+		container.add(
+			new TextRenderable(this.renderer, {
+				content: "  Files will be deleted from disk.".padEnd(inner),
+				fg: theme.fgSecondary,
+			}),
+		);
+		container.add(
+			new TextRenderable(this.renderer, { content: " ".repeat(inner) }),
+		);
 
 		const btnRow = new BoxRenderable(this.renderer, {
 			width: inner,

--- a/src/layout/toast.ts
+++ b/src/layout/toast.ts
@@ -22,7 +22,6 @@ export interface ToastConfig {
 export class Toast {
 	private renderer: CliRenderer;
 	private config: ToastConfig;
-	private layout: LayoutDimensions;
 	private x: number;
 	private y: number;
 	private height: number;

--- a/src/layout/toast.ts
+++ b/src/layout/toast.ts
@@ -22,6 +22,7 @@ export interface ToastConfig {
 export class Toast {
 	private renderer: CliRenderer;
 	private config: ToastConfig;
+	private layout: LayoutDimensions;
 	private x: number;
 	private y: number;
 	private height: number;
@@ -29,8 +30,6 @@ export class Toast {
 	private createdAt: number;
 	private dismissed: boolean = false;
 	private addedToRenderer: boolean = false;
-
-	private layout: LayoutDimensions;
 	private container: BoxRenderable;
 	private titleLabel: TextRenderable;
 	private messageLabel: TextRenderable;

--- a/src/layout/torrent-view.ts
+++ b/src/layout/torrent-view.ts
@@ -101,6 +101,8 @@ function formatStatus(status: TorrentState["status"]): string {
 			return "Stopped";
 		case "error":
 			return "Error";
+		case "missing":
+			return "Missing";
 	}
 }
 
@@ -277,6 +279,8 @@ export class TorrentTable {
 					return theme.fgSecondary;
 				case "error":
 					return theme.error;
+				case "missing":
+					return theme.warning;
 				default:
 					return theme.accent;
 			}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -7,7 +7,8 @@ export type TorrentUiStatus =
 	| "paused"
 	| "seeding"
 	| "stopped"
-	| "error";
+	| "error"
+	| "missing";
 
 export interface TorrentFileState {
 	path: string;

--- a/src/torrent/bridge.ts
+++ b/src/torrent/bridge.ts
@@ -614,19 +614,6 @@ export class TorrentBridge {
 		return new TorrentMetadata(decoded as { [key: string]: BencodeValue }, raw);
 	}
 
-	private loadResumeCount(infoHash: string): number {
-		const path = join(getDataDir(), "resume", `${infoHash}.json`);
-		if (!existsSync(path)) return 0;
-		try {
-			const data = JSON.parse(readFileSync(path, "utf-8")) as {
-				downloadedPieces?: number[];
-			};
-			return data.downloadedPieces?.length ?? 0;
-		} catch {
-			return 0;
-		}
-	}
-
 	private registryPath(): string {
 		return join(getDataDir(), "session.json");
 	}

--- a/src/torrent/bridge.ts
+++ b/src/torrent/bridge.ts
@@ -9,8 +9,13 @@ import { log, TorrentMetadata } from "./metadata";
 import type { BencodeValue } from "./parser";
 import { decode } from "./parser";
 import { PeerManager } from "./peer/manager";
+import {
+	loadTrustedResumeData,
+	readResumeData,
+	writeResumeData,
+} from "./resume";
 import { TorrentSession } from "./session";
-import { StorageManager } from "./storage";
+import { StorageManager, VerificationCancelledError } from "./storage";
 import { announce } from "./tracker/announce";
 
 interface TorrentEntry {
@@ -18,12 +23,22 @@ interface TorrentEntry {
 	session: TorrentSession | null;
 	manager: PeerManager | null;
 	downloader: Downloader | null;
+	checkingAbort: AbortController | null;
+	checkingPromise: Promise<void> | null;
 	state: TorrentState;
 }
 
 interface SessionRegistry {
 	schemaVersion: number;
 	torrents: Array<{ infoHash: string; torrentPath: string }>;
+}
+
+interface RestoreCheckJob {
+	current: number;
+	id: string;
+	metadata: TorrentMetadata;
+	onProgress?: (progress: RestoreProgress) => void;
+	total: number;
 }
 
 export interface RestoreProgress {
@@ -45,7 +60,8 @@ export class TorrentBridge {
 	private store: Store;
 	private config: AppSettings;
 	private torrents: Map<string, TorrentEntry> = new Map();
-	private trustedRestores: string[] = [];
+	private restoreCheckQueue: RestoreCheckJob[] = [];
+	private restoreCheckRunning = false;
 	private pendingFlush = false;
 	private downloadPath: string;
 
@@ -74,7 +90,7 @@ export class TorrentBridge {
 
 		const total = registry.torrents.length;
 		let current = 0;
-		this.trustedRestores = [];
+		this.restoreCheckQueue = [];
 
 		for (const { infoHash, torrentPath } of registry.torrents) {
 			current++;
@@ -84,53 +100,37 @@ export class TorrentBridge {
 				const actualId = Buffer.from(metadata.infoHash).toString("hex");
 				if (actualId !== infoHash) continue;
 
-				const resumeCount = this.loadResumeCount(infoHash);
-				const resumeComplete = resumeCount >= metadata.pieceCount;
-				let downloadedPieces = resumeComplete ? metadata.pieceCount : 0;
-				let status: TorrentState["status"] = resumeComplete
-					? "seeding"
-					: "stopped";
+				const trustedResume = loadTrustedResumeData(
+					metadata,
+					this.downloadPath,
+				);
+				const downloadedPieces = trustedResume?.verifiedPieces.length ?? 0;
+				const resumeComplete = downloadedPieces >= metadata.pieceCount;
 
-				if (!resumeComplete) {
-					const storage = new StorageManager(metadata, this.downloadPath);
-					const summary = await storage.verifyAll({
-						tolerateMissing: true,
-						onProgress: (checked, valid) => {
-							onProgress?.({
-								current,
-								total,
-								name: metadata.name,
-								checkedPieces: checked,
-								totalPieces: metadata.pieceCount,
-								trustedComplete: false,
-							});
-							downloadedPieces = valid;
-						},
-					});
-					downloadedPieces = storage.downloadedCount;
-					status =
-						downloadedPieces === metadata.pieceCount
-							? "seeding"
-							: downloadedPieces < resumeCount || summary.corrupt > 0
-								? "error"
-								: "stopped";
-				} else {
-					this.trustedRestores.push(infoHash);
-					onProgress?.({
-						current,
-						total,
-						name: metadata.name,
-						checkedPieces: metadata.pieceCount,
-						totalPieces: metadata.pieceCount,
-						trustedComplete: true,
-					});
+				if (!trustedResume) {
+					const resumeData = readResumeData(infoHash);
+					const resumeCount =
+						resumeData?.verifiedPieces?.length ??
+						resumeData?.downloadedPieces?.length ??
+						0;
+					if (resumeCount >= metadata.pieceCount) {
+						log("restore", `${metadata.name}   resume data stale; rechecking`);
+					}
 				}
+
+				const finalStatus: TorrentState["status"] = resumeComplete
+					? "seeding"
+					: trustedResume
+						? "stopped"
+						: "checking";
 
 				const entry: TorrentEntry = {
 					torrentPath,
 					session: null,
 					manager: null,
 					downloader: null,
+					checkingAbort: null,
+					checkingPromise: null,
 					state: {
 						id: infoHash,
 						name: metadata.name,
@@ -138,7 +138,7 @@ export class TorrentBridge {
 						pieceLength: metadata.pieceLength,
 						downloadedPieces,
 						totalPieces: metadata.pieceCount,
-						status,
+						status: finalStatus,
 						downloadBps: 0,
 						uploadBps: 0,
 						peers: 0,
@@ -151,9 +151,29 @@ export class TorrentBridge {
 					},
 				};
 				this.torrents.set(infoHash, entry);
+
+				if (!trustedResume) {
+					this.restoreCheckQueue.push({
+						current,
+						id: infoHash,
+						metadata,
+						onProgress,
+						total,
+					});
+				} else {
+					onProgress?.({
+						current,
+						total,
+						name: metadata.name,
+						checkedPieces: metadata.pieceCount,
+						totalPieces: metadata.pieceCount,
+						trustedComplete: true,
+					});
+				}
+
 				log(
 					"restore",
-					`${metadata.name}   ${downloadedPieces}/${metadata.pieceCount} pieces   ${status}`,
+					`${metadata.name}   ${downloadedPieces}/${metadata.pieceCount} pieces   ${finalStatus}`,
 				);
 			} catch {
 				// skip invalid/unreadable torrent files
@@ -161,51 +181,129 @@ export class TorrentBridge {
 		}
 
 		this.flushAll();
+		this.startRestoreCheckQueue();
 	}
 
 	async verifyTrustedRestores(): Promise<void> {
-		const trustedIds = [...this.trustedRestores];
-		this.trustedRestores = [];
+		// Deprecated — verification now runs via restore check queue
+	}
 
-		for (const id of trustedIds) {
-			const entry = this.torrents.get(id);
-			if (!entry) continue;
+	private startRestoreCheckQueue(): void {
+		if (this.restoreCheckRunning) return;
+		this.restoreCheckRunning = true;
+		void this.runRestoreCheckQueue();
+	}
 
-			try {
-				const metadata = this.parseTorrent(entry.torrentPath);
-				const storage = new StorageManager(metadata, this.downloadPath);
-				const summary = await storage.verifyAll({
-					tolerateMissing: true,
-					yieldEveryPieces: 8,
-					yieldEveryMs: 16,
-				});
-				if (
-					summary.valid === metadata.pieceCount &&
-					summary.missing === 0 &&
-					summary.corrupt === 0
-				) {
-					this.updateEntry(id, {
-						downloadedPieces: metadata.pieceCount,
-						status: "seeding",
-					});
-					continue;
-				}
-
-				this.updateEntry(id, {
-					downloadedPieces: summary.valid,
-					status: "error",
-					downloadBps: 0,
-					uploadBps: 0,
-					etaSeconds: null,
-				});
-			} catch {
-				this.updateEntry(id, {
-					status: "error",
-					downloadBps: 0,
-					uploadBps: 0,
-					etaSeconds: null,
-				});
+	private async runRestoreCheckQueue(): Promise<void> {
+		try {
+			while (this.restoreCheckQueue.length > 0) {
+				const job = this.restoreCheckQueue.shift();
+				if (!job || !this.torrents.has(job.id)) continue;
+				await this.runRestoreCheck(job);
 			}
+		} finally {
+			this.restoreCheckRunning = false;
+			if (this.restoreCheckQueue.length > 0) this.startRestoreCheckQueue();
+		}
+	}
+
+	private async runRestoreCheck(job: RestoreCheckJob): Promise<void> {
+		const entry = this.torrents.get(job.id);
+		if (!entry) return;
+
+		const controller = new AbortController();
+		entry.checkingAbort = controller;
+
+		const checkPromise = this.verifyRestoreJob(job, controller);
+		entry.checkingPromise = checkPromise;
+		try {
+			await checkPromise;
+		} finally {
+			const current = this.torrents.get(job.id);
+			if (current?.checkingPromise === checkPromise) {
+				current.checkingAbort = null;
+				current.checkingPromise = null;
+			}
+		}
+	}
+
+	private async verifyRestoreJob(
+		job: RestoreCheckJob,
+		controller: AbortController,
+	): Promise<void> {
+		const storage = new StorageManager(job.metadata, this.downloadPath);
+		try {
+			const resumeData = readResumeData(job.id);
+			const resumeCount =
+				resumeData?.verifiedPieces?.length ??
+				resumeData?.downloadedPieces?.length ??
+				0;
+			const summary = await storage.verifyAll({
+				tolerateMissing: true,
+				signal: controller.signal,
+				onProgress: (checked, valid) => {
+					this.updateEntry(job.id, {
+						downloadedPieces: valid,
+						status: "checking",
+					});
+					job.onProgress?.({
+						current: job.current,
+						total: job.total,
+						name: job.metadata.name,
+						checkedPieces: checked,
+						totalPieces: job.metadata.pieceCount,
+						trustedComplete: false,
+					});
+				},
+			});
+
+			if (summary.corrupt === 0) {
+				writeResumeData(
+					job.metadata,
+					this.downloadPath,
+					storage.getDownloadedPieces(),
+				);
+			}
+
+			const downloadedPieces = storage.downloadedCount;
+			const status =
+				downloadedPieces === job.metadata.pieceCount
+					? "seeding"
+					: summary.missing > 0
+						? "missing"
+						: downloadedPieces < resumeCount || summary.corrupt > 0
+							? "error"
+							: "stopped";
+			this.updateEntry(job.id, {
+				downloadedPieces,
+				status,
+				downloadBps: 0,
+				uploadBps: 0,
+				etaSeconds: null,
+			});
+			log(
+				"restore",
+				`${job.metadata.name}   ${downloadedPieces}/${job.metadata.pieceCount} pieces   ${status}`,
+			);
+		} catch (err) {
+			if (
+				err instanceof VerificationCancelledError ||
+				controller.signal.aborted
+			) {
+				this.updateEntry(job.id, {
+					status: "stopped",
+					downloadBps: 0,
+					uploadBps: 0,
+					etaSeconds: null,
+				});
+				return;
+			}
+			this.updateEntry(job.id, {
+				status: "error",
+				downloadBps: 0,
+				uploadBps: 0,
+				etaSeconds: null,
+			});
 		}
 	}
 
@@ -220,6 +318,8 @@ export class TorrentBridge {
 			session: null,
 			manager: null,
 			downloader: null,
+			checkingAbort: null,
+			checkingPromise: null,
 			state: {
 				id,
 				name: metadata.name,
@@ -249,6 +349,11 @@ export class TorrentBridge {
 	async startTorrent(id: string): Promise<void> {
 		const entry = this.torrents.get(id);
 		if (!entry || entry.session !== null) return;
+		if (entry.state.status === "checking" && !entry.checkingPromise) return;
+		if (entry.checkingPromise) {
+			await entry.checkingPromise.catch(() => {});
+			if (!this.torrents.has(id)) return;
+		}
 		const metadata = this.parseTorrent(entry.torrentPath);
 		await this.runDownload(id, metadata);
 	}
@@ -275,6 +380,13 @@ export class TorrentBridge {
 		const entry = this.torrents.get(id);
 		if (!entry) return;
 
+		this.restoreCheckQueue = this.restoreCheckQueue.filter(
+			(job) => job.id !== id,
+		);
+		entry.checkingAbort?.abort();
+		if (entry.checkingPromise) {
+			await entry.checkingPromise.catch(() => {});
+		}
 		entry.downloader?.stop();
 		entry.manager?.close();
 
@@ -302,10 +414,15 @@ export class TorrentBridge {
 	}
 
 	async stopAll(): Promise<void> {
+		const checking: Promise<void>[] = [];
+		this.restoreCheckQueue = [];
 		for (const entry of this.torrents.values()) {
+			entry.checkingAbort?.abort();
+			if (entry.checkingPromise) checking.push(entry.checkingPromise);
 			entry.downloader?.stop();
 			entry.manager?.close();
 		}
+		await Promise.allSettled(checking);
 		this.torrents.clear();
 		this.store.setState({
 			torrents: [],
@@ -323,6 +440,8 @@ export class TorrentBridge {
 
 		const session = new TorrentSession(metadata, this.downloadPath);
 		entry.session = session;
+		const checkingAbort = new AbortController();
+		entry.checkingAbort = checkingAbort;
 
 		session.on("status", (next: string) => {
 			if (!this.torrents.has(id)) return;
@@ -355,11 +474,31 @@ export class TorrentBridge {
 		});
 
 		try {
-			await session.startWithOptions({
+			const checkingPromise = session.startWithOptions({
 				verifyYieldEveryPieces: 8,
 				verifyYieldEveryMs: 16,
+				signal: checkingAbort.signal,
 			});
-		} catch {
+			entry.checkingPromise = checkingPromise;
+			await checkingPromise;
+		} catch (err) {
+			entry.checkingAbort = null;
+			entry.checkingPromise = null;
+			if (!this.torrents.has(id)) return;
+			if (
+				err instanceof VerificationCancelledError ||
+				session.status === "stopped" ||
+				checkingAbort.signal.aborted
+			) {
+				entry.session = null;
+				this.updateEntry(id, {
+					status: "stopped",
+					downloadBps: 0,
+					uploadBps: 0,
+					etaSeconds: null,
+				});
+				return;
+			}
 			entry.session = null;
 			this.updateEntry(id, {
 				status: "error",
@@ -369,6 +508,10 @@ export class TorrentBridge {
 			});
 			return;
 		}
+		entry.checkingAbort = null;
+		entry.checkingPromise = null;
+
+		if (!this.torrents.has(id)) return;
 
 		const complete = session.storage.downloadedCount === metadata.pieceCount;
 		this.updateEntry(id, {
@@ -381,6 +524,7 @@ export class TorrentBridge {
 
 		const trackerResult = await announce(metadata).catch(() => null);
 		const peers = trackerResult?.peers ?? [];
+		if (!this.torrents.has(id)) return;
 
 		const manager = new PeerManager(metadata, this.config.maxConnections);
 		entry.manager = manager;
@@ -388,6 +532,10 @@ export class TorrentBridge {
 		try {
 			await manager.start();
 			await manager.connect(peers);
+			if (!this.torrents.has(id)) {
+				manager.close();
+				return;
+			}
 		} catch {
 			manager.close();
 			entry.manager = null;

--- a/src/torrent/downloader.ts
+++ b/src/torrent/downloader.ts
@@ -1,15 +1,16 @@
 import { EventEmitter } from "node:events";
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
 import { SHA1 } from "bun";
-import { log } from "./metadata.ts";
-import { PiecePicker } from "./piece-picker.ts";
-import { getDataDir } from "../utils/paths.ts";
-import { writeJsonAtomic } from "../utils/json";
 import type { TorrentMetadata } from "./metadata.ts";
-import type { StorageManager } from "./storage.ts";
-import type { PeerManager } from "./peer/manager.ts";
+import { log } from "./metadata.ts";
 import type { PeerConnection } from "./peer/connection.ts";
+import type { PeerManager } from "./peer/manager.ts";
+import { PiecePicker } from "./piece-picker.ts";
+import {
+	infoHashHex,
+	loadTrustedResumeData,
+	writeResumeData,
+} from "./resume.ts";
+import type { StorageManager } from "./storage.ts";
 
 const BLOCK_SIZE = 16_384;
 const PIPELINE_DEPTH = 15;
@@ -93,7 +94,8 @@ export class Downloader extends EventEmitter {
 	private wirePeer(conn: PeerConnection): void {
 		const key = `${conn.address}:${conn.port}`;
 		if (this.bannedPeers.has(key)) return;
-		if (!this.pendingRequests.has(key)) this.pendingRequests.set(key, new Set());
+		if (!this.pendingRequests.has(key))
+			this.pendingRequests.set(key, new Set());
 
 		// Tell the peer what pieces we already have
 		if (this.storage.downloadedCount > 0) {
@@ -149,7 +151,9 @@ export class Downloader extends EventEmitter {
 		}
 	}
 
-	private nextBlock(conn: PeerConnection): { pieceIndex: number; begin: number; length: number } | null {
+	private nextBlock(
+		conn: PeerConnection,
+	): { pieceIndex: number; begin: number; length: number } | null {
 		// Tier 1: finish any in-progress piece this peer has (avoids partial waste)
 		for (const [pieceIndex, piece] of this.inProgress) {
 			if (!conn.hasPiece(pieceIndex)) continue;
@@ -167,7 +171,11 @@ export class Downloader extends EventEmitter {
 		if (pieceIndex === null) return null;
 
 		const total = this.pieceBlockCount(pieceIndex);
-		this.inProgress.set(pieceIndex, { blocks: new Array(total).fill(null), received: 0, total });
+		this.inProgress.set(pieceIndex, {
+			blocks: new Array(total).fill(null),
+			received: 0,
+			total,
+		});
 		return { pieceIndex, begin: 0, length: this.blockLength(pieceIndex, 0) };
 	}
 
@@ -178,7 +186,12 @@ export class Downloader extends EventEmitter {
 		return false;
 	}
 
-	private onBlock(conn: PeerConnection, index: number, begin: number, block: Uint8Array): void {
+	private onBlock(
+		conn: PeerConnection,
+		index: number,
+		begin: number,
+		block: Uint8Array,
+	): void {
 		const key = `${conn.address}:${conn.port}`;
 		const reqKey = `${index}:${begin}`;
 		this.pendingRequests.get(key)?.delete(reqKey);
@@ -206,15 +219,23 @@ export class Downloader extends EventEmitter {
 		if (!this.stopped) this.fillPipeline(conn);
 	}
 
-	private finishPiece(index: number, piece: InProgressPiece, conn: PeerConnection): void {
+	private finishPiece(
+		index: number,
+		piece: InProgressPiece,
+		conn: PeerConnection,
+	): void {
 		const key = `${conn.address}:${conn.port}`;
 		this.inProgress.delete(index);
 
 		// Assemble blocks
-		const assembled = Buffer.concat(piece.blocks.filter((b): b is Buffer => b !== null));
+		const assembled = Buffer.concat(
+			piece.blocks.filter((b): b is Buffer => b !== null),
+		);
 
 		// SHA-1 verify in memory
-		const actual = new SHA1().update(assembled).digest() as unknown as Uint8Array;
+		const actual = new SHA1()
+			.update(assembled)
+			.digest() as unknown as Uint8Array;
 		const expected = this.metadata.pieceHashes[index];
 
 		if (!expected || !bufEqual(actual, expected)) {
@@ -297,47 +318,28 @@ export class Downloader extends EventEmitter {
 
 	// Resume
 
-	private resumePath(): string {
-		const hex = Buffer.from(this.metadata.infoHash).toString("hex");
-		return join(getDataDir(), "resume", `${hex}.json`);
-	}
-
 	private loadResume(): void {
-		const path = this.resumePath();
-		if (!existsSync(path)) {
+		const resume = loadTrustedResumeData(this.metadata, this.downloadPath);
+		if (!resume) {
 			log("resume", "no saved state — starting fresh");
 			return;
 		}
-		try {
-			const data = JSON.parse(readFileSync(path, "utf-8")) as {
-				infoHash: string;
-				downloadPath: string;
-				downloadedPieces: number[];
-			};
-			if (data.downloadPath !== this.downloadPath) {
-				log("resume", "download path changed — starting fresh");
-				return;
-			}
-			// Only count pieces that verifyAll() already confirmed are on disk.
-			// Do not call markPiece() here — verifyAll() is the authoritative source.
-			// Marking stale resume entries would corrupt the download when files were deleted.
-			const confirmed = data.downloadedPieces.filter((i) => this.storage.hasPiece(i)).length;
-			log("resume", `${confirmed} / ${data.downloadedPieces.length} resume pieces confirmed on disk`);
-		} catch {
-			log("resume", "could not read save file — starting fresh");
+
+		for (const piece of resume.verifiedPieces) {
+			this.storage.markPiece(piece);
 		}
+		log(
+			"resume",
+			`${resume.verifiedPieces.length} / ${this.metadata.pieceCount} trusted resume pieces for ${infoHashHex(this.metadata).slice(0, 8)}`,
+		);
 	}
 
 	private saveResume(): void {
-		const path = this.resumePath();
-		const data = {
-			schemaVersion: 1,
-			infoHash: Buffer.from(this.metadata.infoHash).toString("hex"),
-			downloadPath: this.downloadPath,
-			downloadedPieces: [...this.storage.getDownloadedPieces()],
-			savedAt: Math.floor(Date.now() / 1000),
-		};
-		writeJsonAtomic(path, data);
+		writeResumeData(
+			this.metadata,
+			this.downloadPath,
+			this.storage.getDownloadedPieces(),
+		);
 	}
 }
 

--- a/src/torrent/metadata.ts
+++ b/src/torrent/metadata.ts
@@ -1,6 +1,6 @@
 import { SHA1 } from "bun";
-import { extractInfoBytes } from "./parser.ts";
 import type { BencodeValue } from "./parser.ts";
+import { extractInfoBytes } from "./parser.ts";
 import type { FileInfo } from "./types.ts";
 
 const TEXT_DECODER = new TextDecoder();
@@ -20,8 +20,11 @@ export class TorrentMetadata {
 	readonly infoHash: Uint8Array;
 	readonly announceList: string[][];
 
-	constructor(decoded: { [key: string]: BencodeValue }, rawTorrentBytes: Uint8Array) {
-		const info = decoded["info"];
+	constructor(
+		decoded: { [key: string]: BencodeValue },
+		rawTorrentBytes: Uint8Array,
+	) {
+		const info = decoded.info;
 		if (
 			typeof info !== "object" ||
 			info === null ||
@@ -33,14 +36,12 @@ export class TorrentMetadata {
 		const infoDict = info as { [key: string]: BencodeValue };
 
 		// name
-		const nameRaw = infoDict["name"];
+		const nameRaw = infoDict.name;
 		if (!(nameRaw instanceof Uint8Array) && typeof nameRaw !== "string") {
 			throw new Error("Missing name in info dict");
 		}
 		this.name =
-			nameRaw instanceof Uint8Array
-				? TEXT_DECODER.decode(nameRaw)
-				: nameRaw;
+			nameRaw instanceof Uint8Array ? TEXT_DECODER.decode(nameRaw) : nameRaw;
 
 		// piece length
 		const pl = infoDict["piece length"];
@@ -48,7 +49,7 @@ export class TorrentMetadata {
 		this.pieceLength = pl;
 
 		// piece hashes
-		const piecesRaw = infoDict["pieces"];
+		const piecesRaw = infoDict.pieces;
 		if (!(piecesRaw instanceof Uint8Array)) {
 			throw new Error("Missing or invalid pieces");
 		}
@@ -64,8 +65,8 @@ export class TorrentMetadata {
 		// file list
 		this.files = [];
 		let offset = 0;
-		const lengthField = infoDict["length"];
-		const filesField = infoDict["files"];
+		const lengthField = infoDict.length;
+		const filesField = infoDict.files;
 
 		if (typeof lengthField === "number") {
 			// single-file torrent
@@ -83,8 +84,8 @@ export class TorrentMetadata {
 					throw new Error("Invalid file entry");
 				}
 				const fileDict = entry as { [key: string]: BencodeValue };
-				const fileLen = fileDict["length"];
-				const filePath = fileDict["path"];
+				const fileLen = fileDict.length;
+				const filePath = fileDict.path;
 				if (typeof fileLen !== "number") throw new Error("Invalid file length");
 				if (!Array.isArray(filePath)) throw new Error("Invalid file path");
 
@@ -105,7 +106,9 @@ export class TorrentMetadata {
 
 		// Hash the raw bytes from the original file — not a re-encoded version.
 		// BEP 3: must extract the substring directly, not decode-encode roundtrip.
-		this.infoHash = SHA1.hash(extractInfoBytes(rawTorrentBytes)) as unknown as Uint8Array;
+		this.infoHash = SHA1.hash(
+			extractInfoBytes(rawTorrentBytes),
+		) as unknown as Uint8Array;
 
 		// announce list (BEP 12)
 		const announceListRaw = decoded["announce-list"];
@@ -123,7 +126,7 @@ export class TorrentMetadata {
 				)
 				.filter((tier) => tier.length > 0);
 		} else {
-			const announce = decoded["announce"];
+			const announce = decoded.announce;
 			const announceStr =
 				announce instanceof Uint8Array
 					? TEXT_DECODER.decode(announce)
@@ -159,8 +162,11 @@ export class TorrentMetadata {
 			: this.pieceLength;
 		const pieceEnd = pieceStart + pieceLen;
 
-		const ranges: Array<{ file: FileInfo; fileOffset: number; length: number }> =
-			[];
+		const ranges: Array<{
+			file: FileInfo;
+			fileOffset: number;
+			length: number;
+		}> = [];
 
 		for (const file of this.files) {
 			const fileEnd = file.offset + file.length;
@@ -178,13 +184,22 @@ export class TorrentMetadata {
 	}
 
 	logSummary(): void {
-		const httpTrackers = this.announceList.flat().filter((u) => u.startsWith("http")).length;
-		const udpTrackers = this.announceList.flat().filter((u) => u.startsWith("udp")).length;
+		const httpTrackers = this.announceList
+			.flat()
+			.filter((u) => u.startsWith("http")).length;
+		const udpTrackers = this.announceList
+			.flat()
+			.filter((u) => u.startsWith("udp")).length;
 		const trackerParts = [
 			httpTrackers > 0 ? `${httpTrackers} HTTP` : "",
 			udpTrackers > 0 ? `${udpTrackers} UDP` : "",
-		].filter(Boolean).join("  ");
+		]
+			.filter(Boolean)
+			.join("  ");
 
-		log("torrent", `${this.name}   ${this.formatSize()}   ${this.pieceCount} × ${this.formatPieceLength()}   ${trackerParts || "no trackers"}`);
+		log(
+			"torrent",
+			`${this.name}   ${this.formatSize()}   ${this.pieceCount} × ${this.formatPieceLength()}   ${trackerParts || "no trackers"}`,
+		);
 	}
 }

--- a/src/torrent/parser.ts
+++ b/src/torrent/parser.ts
@@ -116,16 +116,19 @@ export function decode(data: Uint8Array): BencodeValue {
 function skipValue(data: Uint8Array, i: number): number {
 	const byte = data[i];
 	if (byte === undefined) throw new Error(`Unexpected end at ${i}`);
-	if (byte === 105) { // integer: i<digits>e
+	if (byte === 105) {
+		// integer: i<digits>e
 		while (i < data.length && data[i] !== 101) i++;
 		return i + 1;
 	}
-	if (byte === 108) { // list: l<items>e
+	if (byte === 108) {
+		// list: l<items>e
 		i++;
 		while (i < data.length && data[i] !== 101) i = skipValue(data, i);
 		return i + 1;
 	}
-	if (byte === 100) { // dict: d<key><value>...e
+	if (byte === 100) {
+		// dict: d<key><value>...e
 		i++;
 		while (i < data.length && data[i] !== 101) {
 			i = skipValue(data, i); // key
@@ -133,7 +136,8 @@ function skipValue(data: Uint8Array, i: number): number {
 		}
 		return i + 1;
 	}
-	if (byte >= 48 && byte <= 57) { // string: <len>:<bytes>
+	if (byte >= 48 && byte <= 57) {
+		// string: <len>:<bytes>
 		let j = i;
 		while (j < data.length && data[j] !== 58) j++;
 		const len = Number.parseInt(TEXT_DECODER.decode(data.slice(i, j)), 10);

--- a/src/torrent/peer/connection.ts
+++ b/src/torrent/peer/connection.ts
@@ -1,21 +1,21 @@
 import { EventEmitter } from "node:events";
-import { createConnection } from "node:net";
 import type { Socket } from "node:net";
+import { createConnection } from "node:net";
 import { log } from "../metadata.ts";
+import { buildHandshake, HANDSHAKE_LEN, parseHandshake } from "./handshake.ts";
 import { MessageBuffer } from "./message-buffer.ts";
+import { getPeerId } from "./peer-id.ts";
 import {
-	MSG,
-	decode as decodeMsg,
-	encode as encodeMsg,
-	encodeHave,
-	encodeRequest,
-	encodeCancel,
 	decodeHave,
+	decode as decodeMsg,
 	decodePiece,
 	decodeRequest,
+	encodeCancel,
+	encodeHave,
+	encode as encodeMsg,
+	encodeRequest,
+	MSG,
 } from "./protocol.ts";
-import { buildHandshake, parseHandshake, HANDSHAKE_LEN } from "./handshake.ts";
-import { getPeerId } from "./peer-id.ts";
 
 const KEEPALIVE_INTERVAL_MS = 120_000;
 const CONNECT_TIMEOUT_MS = 10_000;
@@ -48,11 +48,7 @@ export class PeerConnection extends EventEmitter {
 	private infoHash: Uint8Array;
 	private settle?: (err?: Error) => void;
 
-	constructor(
-		address: string,
-		port: number,
-		infoHash: Uint8Array,
-	) {
+	constructor(address: string, port: number, infoHash: Uint8Array) {
 		super();
 		this.address = address;
 		this.port = port;
@@ -77,7 +73,10 @@ export class PeerConnection extends EventEmitter {
 			// 10s covers both TCP connect AND handshake completion.
 			// Do NOT clear on TCP connect — only clear when promise settles.
 			const timeout = setTimeout(() => {
-				log("timeout", `${this.address}:${this.port}  after ${CONNECT_TIMEOUT_MS / 1000}s`);
+				log(
+					"timeout",
+					`${this.address}:${this.port}  after ${CONNECT_TIMEOUT_MS / 1000}s`,
+				);
 				sock.destroy();
 				this.settle?.(new Error("connect timeout"));
 			}, CONNECT_TIMEOUT_MS);
@@ -121,7 +120,10 @@ export class PeerConnection extends EventEmitter {
 				this.peerId = result.peerId;
 				this.handshakeDone = true;
 				this.startKeepalive();
-				log("handshake", `${this.address}:${this.port}   ${this.peerId.slice(0, 8)}`);
+				log(
+					"handshake",
+					`${this.address}:${this.port}   ${this.peerId.slice(0, 8)}`,
+				);
 				this.settle?.(); // resolve the connect() promise
 				const remainder = this.handshakeBuffer.slice(HANDSHAKE_LEN);
 				this.handshakeBuffer = new Uint8Array(0);
@@ -191,7 +193,10 @@ export class PeerConnection extends EventEmitter {
 		let n = 0;
 		for (const byte of this.piecesBitfield) {
 			let b = byte;
-			while (b) { n += b & 1; b >>>= 1; }
+			while (b) {
+				n += b & 1;
+				b >>>= 1;
+			}
 		}
 		return n;
 	}

--- a/src/torrent/peer/listener.ts
+++ b/src/torrent/peer/listener.ts
@@ -1,5 +1,5 @@
-import { createServer } from "node:net";
 import type { Server, Socket } from "node:net";
+import { createServer } from "node:net";
 import { log } from "../metadata.ts";
 
 const PORT_RANGE = [6881, 6882, 6883, 6884, 6885, 6886, 6887, 6888, 6889];

--- a/src/torrent/peer/manager.ts
+++ b/src/torrent/peer/manager.ts
@@ -1,11 +1,11 @@
 import { EventEmitter } from "node:events";
-import { log } from "../metadata.ts";
-import { PeerConnection } from "./connection.ts";
-import { PeerListener } from "./listener.ts";
-import { buildHandshake, parseHandshake, HANDSHAKE_LEN } from "./handshake.ts";
-import { getPeerId } from "./peer-id.ts";
 import type { TorrentMetadata } from "../metadata.ts";
+import { log } from "../metadata.ts";
 import type { PeerInfo } from "../types.ts";
+import { PeerConnection } from "./connection.ts";
+import { buildHandshake, HANDSHAKE_LEN, parseHandshake } from "./handshake.ts";
+import { PeerListener } from "./listener.ts";
+import { getPeerId } from "./peer-id.ts";
 
 export class PeerManager extends EventEmitter {
 	readonly connections: Map<string, PeerConnection> = new Map();
@@ -50,7 +50,8 @@ export class PeerManager extends EventEmitter {
 		const conn = new PeerConnection(ip, port, this.infoHash);
 
 		conn.on("bitfield", () => {
-			if (conn.countPiecesPublic() > 0 && !conn.amInterested) conn.sendInterested();
+			if (conn.countPiecesPublic() > 0 && !conn.amInterested)
+				conn.sendInterested();
 		});
 
 		conn.on("disconnect", () => {
@@ -86,7 +87,10 @@ export class PeerManager extends EventEmitter {
 				const ip = socket.remoteAddress ?? "unknown";
 				const port = socket.remotePort ?? 0;
 				const key = `${ip}:${port}`;
-				log("peer", `${key.padEnd(50)}  ok   ${result.peerId.slice(0, 8)}  (inbound)`);
+				log(
+					"peer",
+					`${key.padEnd(50)}  ok   ${result.peerId.slice(0, 8)}  (inbound)`,
+				);
 
 				// Wrap the existing socket in a PeerConnection
 				const conn = new PeerConnection(ip, port, this.infoHash);
@@ -119,7 +123,10 @@ export class PeerManager extends EventEmitter {
 	startChoking(): void {
 		// BEP 3: recalculate every 10s, optimistic rotates every 30s
 		this.chokeTimer = setInterval(() => this.recalculateChokes(), 10_000);
-		this.optimisticTimer = setInterval(() => this.rotateOptimisticUnchoke(), 30_000);
+		this.optimisticTimer = setInterval(
+			() => this.rotateOptimisticUnchoke(),
+			30_000,
+		);
 		// Run immediately so peers are unchoked on download start
 		this.recalculateChokes();
 	}
@@ -144,7 +151,9 @@ export class PeerManager extends EventEmitter {
 
 		// BEP 3: unchoke top 4 by download rate from them (reciprocation)
 		const interested = peers.filter((p) => p.peerInterested);
-		const sorted = [...interested].sort((a, b) => b.downloadBytesPerSec - a.downloadBytesPerSec);
+		const sorted = [...interested].sort(
+			(a, b) => b.downloadBytesPerSec - a.downloadBytesPerSec,
+		);
 		const toUnchoke = new Set<string>();
 
 		for (let i = 0; i < Math.min(4, sorted.length); i++) {
@@ -168,7 +177,9 @@ export class PeerManager extends EventEmitter {
 				.slice(0, 4)
 				.map((k) => {
 					const c = this.connections.get(k);
-					const mbps = ((c?.downloadBytesPerSec ?? 0) / (1024 * 1024)).toFixed(1);
+					const mbps = ((c?.downloadBytesPerSec ?? 0) / (1024 * 1024)).toFixed(
+						1,
+					);
 					return `${c?.peerId.slice(0, 8) ?? k}(${mbps})`;
 				})
 				.join("  ");
@@ -181,7 +192,8 @@ export class PeerManager extends EventEmitter {
 
 	private rotateOptimisticUnchoke(): void {
 		const choked = [...this.connections.values()].filter(
-			(p) => !this.unchokedKeys.has(`${p.address}:${p.port}`) && p.peerInterested,
+			(p) =>
+				!this.unchokedKeys.has(`${p.address}:${p.port}`) && p.peerInterested,
 		);
 		if (choked.length === 0) return;
 
@@ -210,15 +222,6 @@ export class PeerManager extends EventEmitter {
 			seen.add(k);
 			return true;
 		});
-	}
-
-	private countBits(buf: Uint8Array): number {
-		let n = 0;
-		for (const byte of buf) {
-			let b = byte;
-			while (b) { n += b & 1; b >>>= 1; }
-		}
-		return n;
 	}
 
 	close(): void {

--- a/src/torrent/piece-picker.ts
+++ b/src/torrent/piece-picker.ts
@@ -28,7 +28,10 @@ export class PiecePicker {
 	}
 
 	onHave(pieceIndex: number): void {
-		this.availability.set(pieceIndex, (this.availability.get(pieceIndex) ?? 0) + 1);
+		this.availability.set(
+			pieceIndex,
+			(this.availability.get(pieceIndex) ?? 0) + 1,
+		);
 	}
 
 	// Returns the lowest-availability unstarted piece this peer has that we need.

--- a/src/torrent/resume.ts
+++ b/src/torrent/resume.ts
@@ -1,0 +1,147 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { writeJsonAtomic } from "../utils/json.ts";
+import { getDataDir } from "../utils/paths.ts";
+import type { TorrentMetadata } from "./metadata.ts";
+
+export const RESUME_SCHEMA_VERSION = 2;
+
+export interface ResumeFileFingerprint {
+	path: string;
+	length: number;
+	mtimeMs: number;
+}
+
+export interface TorrentResumeData {
+	schemaVersion: number;
+	infoHash: string;
+	downloadPath: string;
+	verifiedPieces: number[];
+	downloadedPieces?: number[];
+	files: ResumeFileFingerprint[];
+	savedAt: number;
+}
+
+export interface TrustedResumeData {
+	data: TorrentResumeData;
+	verifiedPieces: number[];
+}
+
+export function resumePathForInfoHash(infoHash: string): string {
+	return join(getDataDir(), "resume", `${infoHash}.json`);
+}
+
+export function infoHashHex(metadata: TorrentMetadata): string {
+	return Buffer.from(metadata.infoHash).toString("hex");
+}
+
+export function readResumeData(infoHash: string): TorrentResumeData | null {
+	const path = resumePathForInfoHash(infoHash);
+	if (!existsSync(path)) return null;
+
+	try {
+		return JSON.parse(readFileSync(path, "utf-8")) as TorrentResumeData;
+	} catch {
+		return null;
+	}
+}
+
+export function loadTrustedResumeData(
+	metadata: TorrentMetadata,
+	downloadPath: string,
+): TrustedResumeData | null {
+	const infoHash = infoHashHex(metadata);
+	const data = readResumeData(infoHash);
+	if (!data || !isTrustedResumeData(data, metadata, downloadPath)) return null;
+
+	return {
+		data,
+		verifiedPieces: normalizeVerifiedPieces(
+			data.verifiedPieces ?? data.downloadedPieces ?? [],
+			metadata.pieceCount,
+		),
+	};
+}
+
+export function writeResumeData(
+	metadata: TorrentMetadata,
+	downloadPath: string,
+	verifiedPieces: Iterable<number>,
+): void {
+	const infoHash = infoHashHex(metadata);
+	const files = buildFileFingerprints(metadata, downloadPath);
+	if (!files) return;
+
+	const pieces = normalizeVerifiedPieces(
+		[...verifiedPieces],
+		metadata.pieceCount,
+	);
+	writeJsonAtomic(resumePathForInfoHash(infoHash), {
+		schemaVersion: RESUME_SCHEMA_VERSION,
+		infoHash,
+		downloadPath,
+		verifiedPieces: pieces,
+		downloadedPieces: pieces,
+		files,
+		savedAt: Math.floor(Date.now() / 1000),
+	});
+}
+
+export function buildFileFingerprints(
+	metadata: TorrentMetadata,
+	downloadPath: string,
+): ResumeFileFingerprint[] | null {
+	const files: ResumeFileFingerprint[] = [];
+
+	for (const file of metadata.files) {
+		const fullPath = join(downloadPath, file.path);
+		if (!existsSync(fullPath)) return null;
+		const stat = statSync(fullPath);
+		files.push({
+			path: file.path,
+			length: stat.size,
+			mtimeMs: Math.trunc(stat.mtimeMs),
+		});
+	}
+
+	return files;
+}
+
+function isTrustedResumeData(
+	data: TorrentResumeData,
+	metadata: TorrentMetadata,
+	downloadPath: string,
+): boolean {
+	if (data.schemaVersion !== RESUME_SCHEMA_VERSION) return false;
+	if (data.infoHash !== infoHashHex(metadata)) return false;
+	if (data.downloadPath !== downloadPath) return false;
+	if (!Array.isArray(data.files)) return false;
+	if (data.files.length !== metadata.files.length) return false;
+
+	const current = buildFileFingerprints(metadata, downloadPath);
+	if (!current) return false;
+
+	for (let i = 0; i < current.length; i++) {
+		const expected = data.files[i];
+		const actual = current[i];
+		if (!expected || !actual) return false;
+		if (expected.path !== actual.path) return false;
+		if (expected.length !== actual.length) return false;
+		if (expected.mtimeMs !== actual.mtimeMs) return false;
+	}
+
+	return true;
+}
+
+function normalizeVerifiedPieces(
+	pieces: number[],
+	pieceCount: number,
+): number[] {
+	const unique = new Set<number>();
+	for (const piece of pieces) {
+		if (Number.isInteger(piece) && piece >= 0 && piece < pieceCount) {
+			unique.add(piece);
+		}
+	}
+	return [...unique].sort((a, b) => a - b);
+}

--- a/src/torrent/session.ts
+++ b/src/torrent/session.ts
@@ -2,13 +2,16 @@ import { EventEmitter } from "node:events";
 import { Downloader } from "./downloader.ts";
 import type { TorrentMetadata } from "./metadata.ts";
 import type { PeerManager } from "./peer/manager.ts";
-import { StorageManager } from "./storage.ts";
+import { loadTrustedResumeData } from "./resume.ts";
+import { StorageManager, VerificationCancelledError } from "./storage.ts";
 import type { TorrentStatus } from "./types.ts";
 
 export interface SessionStartOptions {
 	skipVerify?: boolean;
 	verifyYieldEveryPieces?: number;
 	verifyYieldEveryMs?: number;
+	verifyChunkSizeBytes?: number;
+	signal?: AbortSignal;
 }
 
 export class TorrentSession extends EventEmitter {
@@ -37,14 +40,34 @@ export class TorrentSession extends EventEmitter {
 	async startWithOptions(options: SessionStartOptions = {}): Promise<void> {
 		this.transition("checking");
 		const setup = await this.storage.setup();
-		if (!options.skipVerify && !setup.allFilesCreated) {
-			await this.storage.verifyAll({
-				yieldEveryPieces: options.verifyYieldEveryPieces,
-				yieldEveryMs: options.verifyYieldEveryMs,
-				onProgress: (checked: number, valid: number) => {
-					this.emit("checking", checked, this.metadata.pieceCount, valid);
-				},
-			});
+		try {
+			if (options.signal?.aborted) throw new VerificationCancelledError();
+			if (!options.skipVerify && !setup.allFilesCreated) {
+				const trustedResume = loadTrustedResumeData(
+					this.metadata,
+					this.downloadPath,
+				);
+				if (trustedResume) {
+					for (const piece of trustedResume.verifiedPieces) {
+						this.storage.markPiece(piece);
+					}
+				} else {
+					await this.storage.verifyAll({
+						yieldEveryPieces: options.verifyYieldEveryPieces,
+						yieldEveryMs: options.verifyYieldEveryMs,
+						chunkSizeBytes: options.verifyChunkSizeBytes,
+						signal: options.signal,
+						onProgress: (checked: number, valid: number) => {
+							this.emit("checking", checked, this.metadata.pieceCount, valid);
+						},
+					});
+				}
+			}
+		} catch (err) {
+			if (err instanceof VerificationCancelledError) {
+				this.transition("stopped");
+			}
+			throw err;
 		}
 		this.transition("ready");
 	}

--- a/src/torrent/storage.ts
+++ b/src/torrent/storage.ts
@@ -7,6 +7,8 @@ import {
 	readSync,
 	writeSync,
 } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import { open as openAsync } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { SHA1 } from "bun";
 import type { TorrentMetadata } from "./metadata.ts";
@@ -18,10 +20,12 @@ interface StorageSetupSummary {
 	allFilesCreated: boolean;
 }
 
-interface VerifyAllOptions {
+export interface VerifyAllOptions {
 	tolerateMissing?: boolean;
 	yieldEveryPieces?: number;
 	yieldEveryMs?: number;
+	chunkSizeBytes?: number;
+	signal?: AbortSignal;
 	onProgress?: (
 		checked: number,
 		valid: number,
@@ -30,13 +34,23 @@ interface VerifyAllOptions {
 	) => void;
 }
 
-interface VerifyAllSummary {
+export interface VerifyAllSummary {
 	valid: number;
 	missing: number;
 	corrupt: number;
 }
 
 type ReadHandleMap = Map<string, number>;
+type AsyncReadHandleMap = Map<string, FileHandle>;
+
+const DEFAULT_VERIFY_CHUNK_SIZE = 1024 * 1024;
+
+export class VerificationCancelledError extends Error {
+	constructor() {
+		super("Verification cancelled");
+		this.name = "VerificationCancelledError";
+	}
+}
 
 function formatSize(bytes: number): string {
 	const gb = bytes / (1024 * 1024 * 1024);
@@ -174,74 +188,67 @@ export class StorageManager {
 		return bufEqual(actual, expected);
 	}
 
-	// Opens each file once and reads through it sequentially — no per-piece open/close.
+	// Opens each file once and reads through it sequentially, yielding between
+	// chunks so large pieces do not monopolize the TUI event loop.
 	async verifyAll(options: VerifyAllOptions = {}): Promise<VerifyAllSummary> {
 		const tolerateMissing = options.tolerateMissing ?? false;
 		const yieldEveryPieces = options.yieldEveryPieces ?? 8;
 		const yieldEveryMs = options.yieldEveryMs ?? 16;
+		const chunkSizeBytes =
+			options.chunkSizeBytes && options.chunkSizeBytes > 0
+				? options.chunkSizeBytes
+				: DEFAULT_VERIFY_CHUNK_SIZE;
 		let valid = 0;
 		let missing = 0;
 		let corrupt = 0;
 		let lastYield = Date.now();
-		const readHandles: ReadHandleMap = new Map();
+		const syncReadHandles: ReadHandleMap = new Map();
+		const asyncReadHandles: AsyncReadHandleMap = new Map();
 		this.downloadedPieces.clear();
+
+		const maybeYield = async (force = false): Promise<void> => {
+			if (!force && Date.now() - lastYield < yieldEveryMs) return;
+			await yieldToEventLoop();
+			lastYield = Date.now();
+			throwIfAborted(options.signal);
+		};
 
 		try {
 			for (let i = 0; i < this.metadata.pieceCount; i++) {
-				const data = this.readPieceMaybeSync(i, tolerateMissing, readHandles);
-				if (!data) {
+				throwIfAborted(options.signal);
+
+				const pieceState =
+					this.pieceLengthForIndex(i) <= chunkSizeBytes
+						? this.verifyPieceByBuffer(i, tolerateMissing, syncReadHandles)
+						: await this.verifyPieceByChunks(
+								i,
+								tolerateMissing,
+								chunkSizeBytes,
+								asyncReadHandles,
+								options.signal,
+								maybeYield,
+							);
+
+				if (pieceState === "missing") {
 					missing++;
 					options.onProgress?.(i + 1, valid, missing, corrupt);
-					if (
-						(i + 1) % yieldEveryPieces === 0 ||
-						Date.now() - lastYield >= yieldEveryMs
-					) {
-						await yieldToEventLoop();
-						lastYield = Date.now();
-					}
+					await maybeYield((i + 1) % yieldEveryPieces === 0);
 					continue;
 				}
 
-				if (isAllZero(data)) {
-					missing++;
-					options.onProgress?.(i + 1, valid, missing, corrupt);
-					if (
-						(i + 1) % yieldEveryPieces === 0 ||
-						Date.now() - lastYield >= yieldEveryMs
-					) {
-						await yieldToEventLoop();
-						lastYield = Date.now();
-					}
-					continue;
-				}
-
-				const expected = this.metadata.pieceHashes[i];
-				if (!expected) {
+				if (pieceState === "corrupt") {
 					corrupt++;
-					continue;
-				}
-
-				const actual = new SHA1()
-					.update(data)
-					.digest() as unknown as Uint8Array;
-				if (bufEqual(actual, expected)) {
+				} else {
 					valid++;
 					this.downloadedPieces.add(i);
-				} else {
-					corrupt++;
 				}
 
 				options.onProgress?.(i + 1, valid, missing, corrupt);
-				if (
-					(i + 1) % yieldEveryPieces === 0 ||
-					Date.now() - lastYield >= yieldEveryMs
-				) {
-					await yieldToEventLoop();
-					lastYield = Date.now();
-				}
+				await maybeYield((i + 1) % yieldEveryPieces === 0);
 			}
 		} finally {
-			this.closeReadHandles(readHandles);
+			this.closeReadHandles(syncReadHandles);
+			await this.closeAsyncReadHandles(asyncReadHandles);
 		}
 
 		log(
@@ -304,6 +311,117 @@ export class StorageManager {
 		}
 		readHandles.clear();
 	}
+
+	private verifyPieceByBuffer(
+		pieceIndex: number,
+		tolerateMissing: boolean,
+		readHandles: ReadHandleMap,
+	): "valid" | "missing" | "corrupt" {
+		const expected = this.metadata.pieceHashes[pieceIndex];
+		if (!expected) return "corrupt";
+
+		const data = this.readPieceMaybeSync(
+			pieceIndex,
+			tolerateMissing,
+			readHandles,
+		);
+		if (!data || isAllZero(data)) return "missing";
+
+		const actual = new SHA1().update(data).digest() as unknown as Uint8Array;
+		return bufEqual(actual, expected) ? "valid" : "corrupt";
+	}
+
+	private async verifyPieceByChunks(
+		pieceIndex: number,
+		tolerateMissing: boolean,
+		chunkSizeBytes: number,
+		readHandles: AsyncReadHandleMap,
+		signal: AbortSignal | undefined,
+		maybeYield: () => Promise<void>,
+	): Promise<"valid" | "missing" | "corrupt"> {
+		const expected = this.metadata.pieceHashes[pieceIndex];
+		if (!expected) return "corrupt";
+
+		const hash = new SHA1();
+		let sawNonZero = false;
+
+		for (const { file, fileOffset, length } of this.metadata.pieceToFileRanges(
+			pieceIndex,
+		)) {
+			const fullPath = join(this.downloadPath, file.path);
+			const handle = await this.getAsyncReadHandle(
+				fullPath,
+				tolerateMissing,
+				readHandles,
+			);
+			if (!handle) return "missing";
+
+			let remaining = length;
+			let offset = fileOffset;
+			while (remaining > 0) {
+				throwIfAborted(signal);
+
+				const chunkLength = Math.min(remaining, chunkSizeBytes);
+				const chunk = Buffer.allocUnsafe(chunkLength);
+				const { bytesRead } = await handle.read(chunk, 0, chunkLength, offset);
+				if (bytesRead !== chunkLength) {
+					if (tolerateMissing) return "missing";
+					throw new Error(`Short read: ${fullPath}`);
+				}
+
+				if (!sawNonZero && !isAllZero(chunk)) sawNonZero = true;
+				hash.update(chunk);
+				remaining -= bytesRead;
+				offset += bytesRead;
+				await maybeYield();
+			}
+		}
+
+		if (!sawNonZero) return "missing";
+
+		const actual = hash.digest() as unknown as Uint8Array;
+		return bufEqual(actual, expected) ? "valid" : "corrupt";
+	}
+
+	private async getAsyncReadHandle(
+		fullPath: string,
+		tolerateMissing: boolean,
+		readHandles: AsyncReadHandleMap,
+	): Promise<FileHandle | null> {
+		const cached = readHandles.get(fullPath);
+		if (cached) return cached;
+
+		try {
+			const handle = await openAsync(fullPath, "r");
+			readHandles.set(fullPath, handle);
+			return handle;
+		} catch (err) {
+			if (
+				tolerateMissing &&
+				err instanceof Error &&
+				"code" in err &&
+				err.code === "ENOENT"
+			) {
+				return null;
+			}
+			throw err;
+		}
+	}
+
+	private async closeAsyncReadHandles(
+		readHandles: AsyncReadHandleMap,
+	): Promise<void> {
+		const handles = [...readHandles.values()];
+		readHandles.clear();
+		await Promise.all(handles.map((handle) => handle.close().catch(() => {})));
+	}
+
+	private pieceLengthForIndex(pieceIndex: number): number {
+		const isLastPiece = pieceIndex === this.metadata.pieceCount - 1;
+		return isLastPiece
+			? this.metadata.totalSize - pieceIndex * this.metadata.pieceLength
+			: this.metadata.pieceLength;
+	}
 }
 
 function isAllZero(buf: Uint8Array): boolean {
@@ -323,4 +441,10 @@ function bufEqual(a: Uint8Array, b: Uint8Array): boolean {
 
 function yieldToEventLoop(): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+	if (signal?.aborted) {
+		throw new VerificationCancelledError();
+	}
 }

--- a/src/torrent/tracker/announce.ts
+++ b/src/torrent/tracker/announce.ts
@@ -1,8 +1,8 @@
+import type { TorrentMetadata } from "../metadata.ts";
 import { log } from "../metadata.ts";
+import type { TrackerResponse } from "../types.ts";
 import { announceHTTP } from "./http-tracker.ts";
 import { announceUDP } from "./udp-tracker.ts";
-import type { TorrentMetadata } from "../metadata.ts";
-import type { TrackerResponse } from "../types.ts";
 
 export async function announce(
 	metadata: TorrentMetadata,
@@ -25,7 +25,10 @@ export async function announce(
 		if (r?.status === "fulfilled") {
 			for (const p of r.value) {
 				const k = `${p.ip}:${p.port}`;
-				if (!seen.has(k)) { seen.add(k); allPeers.push(p); }
+				if (!seen.has(k)) {
+					seen.add(k);
+					allPeers.push(p);
+				}
 			}
 		}
 	}

--- a/src/torrent/types.ts
+++ b/src/torrent/types.ts
@@ -26,4 +26,5 @@ export type TorrentStatus =
 	| "stalled"
 	| "paused"
 	| "error"
-	| "stopped";
+	| "stopped"
+	| "missing";

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -22,7 +22,10 @@ export function filterTorrents(
 			return torrents.filter((t) => t.status === "paused");
 		case "Stopped":
 			return torrents.filter(
-				(t) => t.status === "stopped" || t.status === "error",
+				(t) =>
+					t.status === "stopped" ||
+					t.status === "error" ||
+					t.status === "missing",
 			);
 		default:
 			return torrents;

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { dirname } from "node:path";
 
 export function writeJsonAtomic(path: string, value: unknown): void {

--- a/tests/torrent/storage-session-downloader.test.ts
+++ b/tests/torrent/storage-session-downloader.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { Store } from "../../src/store/index.ts";
+import { TorrentBridge } from "../../src/torrent/bridge.ts";
 import { Downloader } from "../../src/torrent/downloader.ts";
+import {
+	resumePathForInfoHash,
+	writeResumeData,
+} from "../../src/torrent/resume.ts";
 import { TorrentSession } from "../../src/torrent/session.ts";
-import { StorageManager } from "../../src/torrent/storage.ts";
+import {
+	StorageManager,
+	VerificationCancelledError,
+} from "../../src/torrent/storage.ts";
 import { getDataDir } from "../../src/utils/paths.ts";
 import { splitPieces } from "../helpers/bytes.ts";
 import { FakePeer, FakePeerManager } from "../helpers/fakes.ts";
@@ -81,6 +90,51 @@ describe("StorageManager", () => {
 			expect(Array.from(storage.getBitfield())).toEqual([0b10000000]);
 		});
 	});
+
+	test("yields between verification chunks and can be cancelled", async () => {
+		await withTempDir(async (dir) => {
+			const fixture = singleFileTorrentFixture({
+				content: patternedBytes(256 * 1024),
+				pieceLength: 256 * 1024,
+			});
+			const storage = new StorageManager(fixture.metadata, dir);
+			await storage.setup();
+			storage.writePieceSync(0, fixture.content);
+
+			const controller = new AbortController();
+			setTimeout(() => controller.abort(), 0);
+
+			await expect(
+				storage.verifyAll({
+					chunkSizeBytes: 1024,
+					yieldEveryMs: 0,
+					signal: controller.signal,
+				}),
+			).rejects.toBeInstanceOf(VerificationCancelledError);
+			expect(storage.downloadedCount).toBe(0);
+		});
+	});
+
+	test("reverification clears stale downloaded state for corrupt pieces", async () => {
+		await withTempDir(async (dir) => {
+			const fixture = singleFileTorrentFixture();
+			const storage = new StorageManager(fixture.metadata, dir);
+			await storage.setup();
+			const pieces = splitPieces(fixture.content, fixture.metadata.pieceLength);
+			const first = pieces[0];
+			if (!first) throw new Error("missing fixture piece");
+
+			storage.writePieceSync(0, first);
+			expect((await storage.verifyAll()).valid).toBe(1);
+			expect(storage.downloadedCount).toBe(1);
+
+			storage.writePieceSync(0, new Uint8Array([9, 9, 9, 9]));
+			const summary = await storage.verifyAll({ tolerateMissing: true });
+
+			expect(summary).toEqual({ valid: 0, missing: 2, corrupt: 1 });
+			expect(storage.downloadedCount).toBe(0);
+		});
+	});
 });
 
 describe("TorrentSession", () => {
@@ -131,6 +185,148 @@ describe("TorrentSession", () => {
 			expect(events.at(-1)).toEqual({ checked: 3, total: 3, valid: 1 });
 			expect(session.status).toBe("ready");
 			expect(session.storage.downloadedCount).toBe(1);
+		});
+	});
+
+	test("cancelled verification transitions to stopped", async () => {
+		await withTempDir(async (dir) => {
+			const fixture = singleFileTorrentFixture({
+				content: patternedBytes(256 * 1024),
+				pieceLength: 256 * 1024,
+			});
+			const session = new TorrentSession(fixture.metadata, dir);
+			await session.storage.setup();
+			session.storage.writePieceSync(0, fixture.content);
+			const controller = new AbortController();
+			setTimeout(() => controller.abort(), 0);
+
+			await expect(
+				session.startWithOptions({
+					verifyChunkSizeBytes: 1024,
+					verifyYieldEveryMs: 0,
+					signal: controller.signal,
+				}),
+			).rejects.toBeInstanceOf(VerificationCancelledError);
+
+			expect(session.status).toBe("stopped");
+			expect(session.storage.downloadedCount).toBe(0);
+		});
+	});
+});
+
+describe("TorrentBridge restore", () => {
+	test("trusts matching resume fingerprints without startup verification", async () => {
+		await withIsolatedAppData(async () => {
+			await withTempDir(async (dir) => {
+				const fixture = singleFileTorrentFixture();
+				const storage = new StorageManager(fixture.metadata, dir);
+				await storage.setup();
+				const first = splitPieces(
+					fixture.content,
+					fixture.metadata.pieceLength,
+				)[0];
+				if (!first) throw new Error("missing fixture piece");
+				storage.writePieceSync(0, first);
+				writeResumeData(fixture.metadata, dir, [0]);
+				const torrentPath = writeTorrentAndRegistry(
+					dir,
+					fixture.raw,
+					fixture.metadata,
+				);
+				const store = createTestStore();
+				const bridge = new TorrentBridge(store, {
+					downloadPath: dir,
+					maxConnections: 50,
+					torrentFolder: dir,
+				});
+
+				await bridge.restoreSession();
+
+				expect(torrentPath.endsWith(".torrent")).toBe(true);
+				expect(store.getState().torrents).toHaveLength(1);
+				expect(store.getState().torrents[0]).toMatchObject({
+					downloadedPieces: 1,
+					status: "stopped",
+					totalPieces: 3,
+				});
+			});
+		});
+	});
+
+	test("queues stale resume data for background verification", async () => {
+		await withIsolatedAppData(async () => {
+			await withTempDir(async (dir) => {
+				const fixture = singleFileTorrentFixture();
+				const storage = new StorageManager(fixture.metadata, dir);
+				await storage.setup();
+				writeLegacyResume(fixture.metadata, dir, [0, 1, 2]);
+				writeTorrentAndRegistry(dir, fixture.raw, fixture.metadata);
+				const store = createTestStore();
+				const statuses: string[] = [];
+				store.subscribe((state) => {
+					const status = state.torrents[0]?.status;
+					if (status) statuses.push(status);
+				});
+				const bridge = new TorrentBridge(store, {
+					downloadPath: dir,
+					maxConnections: 50,
+					torrentFolder: dir,
+				});
+
+				await bridge.restoreSession();
+				await waitFor(() => store.getState().torrents[0]?.status === "missing");
+
+				expect(statuses).toContain("checking");
+				expect(store.getState().torrents[0]).toMatchObject({
+					downloadedPieces: 0,
+					status: "missing",
+					totalPieces: 3,
+				});
+			});
+		});
+	});
+
+	test("reopening after payload deletion reports missing instead of error", async () => {
+		await withIsolatedAppData(async () => {
+			await withTempDir(async (dir) => {
+				const fixture = singleFileTorrentFixture();
+				const storage = new StorageManager(fixture.metadata, dir);
+				await storage.setup();
+				const pieces = splitPieces(
+					fixture.content,
+					fixture.metadata.pieceLength,
+				);
+				for (let i = 0; i < pieces.length; i++) {
+					const piece = pieces[i];
+					if (!piece) throw new Error(`missing fixture piece ${i}`);
+					storage.writePieceSync(i, piece);
+				}
+				writeResumeData(
+					fixture.metadata,
+					dir,
+					[0, 1, 2].slice(0, fixture.metadata.pieceCount),
+				);
+				rmSync(join(dir, fixture.metadata.files[0]?.path ?? ""), {
+					force: true,
+				});
+				writeTorrentAndRegistry(dir, fixture.raw, fixture.metadata);
+
+				const store = createTestStore();
+				const bridge = new TorrentBridge(store, {
+					downloadPath: dir,
+					maxConnections: 50,
+					torrentFolder: dir,
+				});
+
+				await bridge.restoreSession();
+				await waitFor(() => store.getState().torrents[0]?.status === "missing");
+
+				expect(store.getState().torrents[0]).toMatchObject({
+					downloadedPieces: 0,
+					status: "missing",
+					totalPieces: 3,
+				});
+			});
 		});
 	});
 });
@@ -246,3 +442,70 @@ describe("Downloader", () => {
 		});
 	});
 });
+
+function patternedBytes(length: number): Uint8Array {
+	const bytes = new Uint8Array(length);
+	for (let i = 0; i < bytes.length; i++) {
+		bytes[i] = (i * 17 + 31) & 0xff;
+	}
+	return bytes;
+}
+
+function createTestStore(): Store {
+	return new Store({
+		selectedIndex: 0,
+		selectedView: "All",
+		torrents: [],
+		totalDownloadBps: 0,
+		totalUploadBps: 0,
+	});
+}
+
+function writeTorrentAndRegistry(
+	dir: string,
+	raw: Uint8Array,
+	metadata: { infoHash: Uint8Array },
+): string {
+	const torrentPath = join(dir, "fixture.torrent");
+	writeFileSync(torrentPath, raw);
+	const infoHash = Buffer.from(metadata.infoHash).toString("hex");
+	const registryDir = getDataDir();
+	mkdirSync(registryDir, { recursive: true });
+	writeFileSync(
+		join(registryDir, "session.json"),
+		JSON.stringify({
+			schemaVersion: 1,
+			torrents: [{ infoHash, torrentPath }],
+		}),
+	);
+	return torrentPath;
+}
+
+function writeLegacyResume(
+	metadata: { infoHash: Uint8Array },
+	downloadPath: string,
+	downloadedPieces: number[],
+): void {
+	const infoHash = Buffer.from(metadata.infoHash).toString("hex");
+	mkdirSync(join(getDataDir(), "resume"), { recursive: true });
+	writeFileSync(
+		resumePathForInfoHash(infoHash),
+		JSON.stringify({
+			schemaVersion: 1,
+			infoHash,
+			downloadPath,
+			downloadedPieces,
+			savedAt: 1,
+		}),
+	);
+}
+
+async function waitFor(fn: () => boolean, timeoutMs = 1000): Promise<void> {
+	const started = Date.now();
+	while (!fn()) {
+		if (Date.now() - started > timeoutMs) {
+			throw new Error("timed out waiting for condition");
+		}
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+}


### PR DESCRIPTION
## Summary

- **Trusted resume data (v2)**: Resume files now store file fingerprints (path, length, mtime) so verification can be skipped on startup when fingerprints match current files on disk.
- **Chunked verification**: Large pieces are verified in configurable chunks (default 1 MB) instead of loading entire pieces into memory, preventing TUI event loop blocking.
- **Verification cancellation**: `AbortSignal` support across the verification pipeline — cancelling during restore or session start transitions torrents to `stopped` instead of `error`.
- **Background restore checks**: Stale resume data (missing fingerprints or mismatched files) is queued for background verification after restore, keeping startup fast.
- **New `missing` status**: Torrents with deleted payload files are reported as `missing` instead of `error`, distinguishing user action from corruption.
- **Dedicated resume module**: Resume logic extracted into `src/torrent/resume.ts` with schema versioning, fingerprint building, and trusted resume validation.
- **Downloader resume rewrite**: Resume loading now uses trusted resume data; only verified pieces are restored to storage.
- **Startup benchmarks**: Added `scripts/benchmark-startup.ts` and `scripts/benchmark-verify.ts` for measuring restore and verification performance.
- **Tests**: Added tests for chunked verification, cancellation, trusted resume trust, stale resume background verification, and payload deletion detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Missing" torrent status to indicate unavailable torrent data.
  * Optimized startup performance by deferring torrent verification to background and leveraging cached session data when available.

* **Bug Fixes**
  * Fixed space key handling for torrents with missing data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryadios/torrent-tui/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->