### PR TITLE
Add DHT and PEX peer discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ torrent-tui 'magnet:?xt=urn:btih:...' --download
 | `torrent-tui <file.torrent> --download` | Run the downloader without launching the TUI. |
 | `torrent-tui <magnet-uri> --download` | Fetch magnet metadata, cache it, then run the downloader without launching the TUI. |
 
-Magnet support currently covers BitTorrent v1 `btih` magnets that include trackers (`tr`) or explicit peers (`x.pe`). DHT-only trackerless magnets are planned for the DHT phase. After metadata is cached, `--verify` and `--handshake` can use the same magnet URI.
+Magnet support covers BitTorrent v1 `btih` magnets with trackers (`tr`), explicit peers (`x.pe`), or DHT-discovered peers. After metadata is cached, `--verify` and `--handshake` can use the same magnet URI.
 
 ## Configuration
 
@@ -169,7 +169,8 @@ The `Downloading` sidebar filter includes queued, checking, connecting, download
 | Peer handshakes and piece download | Available |
 | Resume data | Available |
 | Multi-torrent TUI | Available |
-| Magnet links | Available for tracker-backed v1 magnets |
+| Magnet links | Available for v1 magnets with tracker, explicit-peer, or DHT discovery |
+| Peer discovery | Trackers, DHT, and PEX |
 | Standalone binaries | Not included yet |
 
 ## Development

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,7 @@ import { Store } from "./store";
 import { TorrentBridge } from "./torrent/bridge";
 import { isMagnetUri } from "./torrent/magnet";
 import type { LayoutDimensions } from "./types/layout";
+import { env } from "./utils/env";
 import { calculateLayout } from "./utils/layout";
 
 const INITIAL_STATE = {
@@ -42,7 +43,11 @@ export class App {
 	async start(initialTorrentPath?: string): Promise<void> {
 		const config = loadConfig();
 
-		this.renderer = await createCliRenderer({ exitOnCtrlC: true });
+		this.renderer = await createCliRenderer({
+			exitOnCtrlC: true,
+			openConsoleOnError: env.SHOW_CONSOLE,
+			useConsole: env.SHOW_CONSOLE,
+		});
 		this.store = new Store(INITIAL_STATE);
 		this.layout = calculateLayout(this.renderer.width, this.renderer.height);
 		this.bridge = new TorrentBridge(this.store, config);

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,8 +29,7 @@ Usage:
                                       Download from the command line
 
 Magnet links:
-  Supported for tracker-backed magnets and magnets with x.pe peers.
-  DHT-only magnets require the planned DHT phase.
+  Supported for BitTorrent v1 btih magnets with trackers, x.pe peers, or DHT peers.
   --verify and --handshake can use a magnet after its metadata is cached.
 
 Options:
@@ -213,7 +212,9 @@ async function runHandshake(torrentPath: string): Promise<void> {
 async function runDownload(torrentPath: string): Promise<void> {
 	const { PeerManager } = await import("./torrent/peer/manager");
 	const { getPeerId, peerIdToString } = await import("./torrent/peer/peer-id");
-	const { TrackerCoordinator } = await import("./torrent/tracker/coordinator");
+	const { DiscoveryCoordinator } = await import(
+		"./torrent/discovery/coordinator"
+	);
 	const {
 		createUploadedAccumulator,
 		recordRemovedPeerUpload,
@@ -231,7 +232,7 @@ async function runDownload(torrentPath: string): Promise<void> {
 	const manager = new PeerManager(metadata);
 	await manager.start();
 	const uploadedAccumulator = createUploadedAccumulator();
-	const trackerCoordinator = new TrackerCoordinator(metadata, {
+	const trackerCoordinator = new DiscoveryCoordinator(metadata, manager, {
 		getSnapshot: () => {
 			const downloaded = session.storage.downloadedBytes;
 			const uploaded = uploadedSnapshot(
@@ -258,7 +259,7 @@ async function runDownload(torrentPath: string): Promise<void> {
 		recordRemovedPeerUpload(uploadedAccumulator, conn);
 		if (manager.connections.size === 0) trackerCoordinator.refreshNow();
 	});
-	trackerCoordinator.start();
+	await trackerCoordinator.start();
 
 	manager.startChoking();
 	const downloader = session.download(manager);

--- a/src/torrent/bridge.ts
+++ b/src/torrent/bridge.ts
@@ -4,6 +4,7 @@ import type { AppSettings } from "../config/settings";
 import type { Store, TorrentPeerState, TorrentState } from "../store";
 import { writeJsonAtomic } from "../utils/json";
 import { getDataDir, resolvePath } from "../utils/paths";
+import { DiscoveryCoordinator } from "./discovery/coordinator";
 import type { Downloader } from "./downloader";
 import { parseMagnetUri } from "./magnet";
 import {
@@ -22,7 +23,6 @@ import {
 } from "./resume";
 import { TorrentSession } from "./session";
 import { StorageManager, VerificationCancelledError } from "./storage";
-import { TrackerCoordinator } from "./tracker/coordinator";
 import type { FileInfo, TorrentStatus } from "./types";
 import {
 	createUploadedAccumulator,
@@ -36,7 +36,7 @@ interface TorrentEntry {
 	magnetUri?: string;
 	session: TorrentSession | null;
 	manager: PeerManager | null;
-	trackerCoordinator: TrackerCoordinator | null;
+	trackerCoordinator: DiscoveryCoordinator | null;
 	downloader: Downloader | null;
 	hasTransferActivity: boolean;
 	uploadedAccumulator: UploadedAccumulator;
@@ -686,7 +686,7 @@ export class TorrentBridge {
 
 		const manager = new PeerManager(metadata, this.config.maxConnections);
 		entry.manager = manager;
-		const trackerCoordinator = new TrackerCoordinator(metadata, {
+		const trackerCoordinator = new DiscoveryCoordinator(metadata, manager, {
 			getSnapshot: () => {
 				const current = this.torrents.get(id);
 				const storage = current?.session?.storage ?? session.storage;
@@ -717,7 +717,7 @@ export class TorrentBridge {
 
 		try {
 			await manager.start();
-			trackerCoordinator.start();
+			await trackerCoordinator.start();
 			if (!this.torrents.has(id)) {
 				await trackerCoordinator.stop();
 				manager.close();

--- a/src/torrent/dht/node.ts
+++ b/src/torrent/dht/node.ts
@@ -1,0 +1,380 @@
+import { createSocket, type RemoteInfo, type Socket } from "node:dgram";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getDataDir } from "../../utils/paths.ts";
+import type { BencodeValue } from "../parser.ts";
+import type { PeerInfo } from "../types.ts";
+import {
+	compactNodes,
+	DEFAULT_BOOTSTRAP_NODES,
+	type DhtMessage,
+	type DhtNode,
+	decodeDhtMessage,
+	encodeDhtQuery,
+	encodeDhtResponse,
+	getResponseId,
+	getResponseNodes,
+	getResponsePeers,
+	getResponseToken,
+	nodeIdFromHex,
+	nodeIdHex,
+	randomNodeId,
+	stringBytes,
+	transactionId,
+	transactionKey,
+} from "./protocol.ts";
+import { DhtRoutingTable, isUsablePeer, peerKey } from "./routing.ts";
+
+const DHT_TIMEOUT_MS = 5_000;
+const DHT_LOOKUP_ROUNDS = 4;
+const DHT_ALPHA = 8;
+const DHT_STATE_FILE = "dht.json";
+
+interface PendingQuery {
+	resolve: (message: DhtMessage) => void;
+	reject: (error: Error) => void;
+	timer: unknown;
+}
+
+interface UdpTransport {
+	send(data: Uint8Array, port: number, host: string): Promise<void>;
+	onMessage(cb: (data: Uint8Array, rinfo: RemoteInfo) => void): void;
+	bind(port: number): Promise<number>;
+	close(): void;
+}
+
+interface Scheduler {
+	setTimeout(fn: () => void, delayMs: number): unknown;
+	clearTimeout(handle: unknown): void;
+}
+
+export interface DhtNodeOptions {
+	nodeId?: Uint8Array;
+	port?: number;
+	bootstrapNodes?: PeerInfo[];
+	transport?: UdpTransport;
+	scheduler?: Scheduler;
+	persist?: boolean;
+}
+
+export class DhtClient {
+	readonly nodeId: Uint8Array;
+	readonly routingTable: DhtRoutingTable;
+	private readonly bootstrapNodes: PeerInfo[];
+	private readonly transport: UdpTransport;
+	private readonly scheduler: Scheduler;
+	private readonly persist: boolean;
+	private readonly pending = new Map<string, PendingQuery>();
+	private started = false;
+	private port = 0;
+
+	constructor(options: DhtNodeOptions = {}) {
+		const persisted = options.persist === false ? null : readDhtState();
+		this.nodeId = options.nodeId ?? persisted?.nodeId ?? randomNodeId();
+		this.routingTable = new DhtRoutingTable(this.nodeId);
+		if (persisted) this.routingTable.addMany(persisted.nodes);
+		this.bootstrapNodes = options.bootstrapNodes ?? [
+			...DEFAULT_BOOTSTRAP_NODES,
+			...this.routingTable.peers(),
+		];
+		this.transport = options.transport ?? new DgramTransport();
+		this.scheduler = options.scheduler ?? {
+			setTimeout: (fn, delayMs) => setTimeout(fn, delayMs),
+			clearTimeout: (handle) =>
+				clearTimeout(handle as ReturnType<typeof setTimeout>),
+		};
+		this.persist = options.persist ?? true;
+	}
+
+	async start(port = 6881): Promise<void> {
+		if (this.started) return;
+		this.port = await this.transport.bind(port);
+		this.transport.onMessage((data, rinfo) => this.onMessage(data, rinfo));
+		this.started = true;
+		await this.bootstrap();
+	}
+
+	async bootstrap(): Promise<void> {
+		await Promise.allSettled(
+			this.bootstrapNodes.map((peer) =>
+				this.findNode(peer, this.nodeId).catch(() => undefined),
+			),
+		);
+		this.save();
+	}
+
+	async getPeers(infoHash: Uint8Array): Promise<PeerInfo[]> {
+		const peers = new Map<string, PeerInfo>();
+		const queried = new Set<string>();
+		let frontier = this.routingTable.closest(infoHash, DHT_ALPHA);
+		if (frontier.length === 0) {
+			frontier = this.bootstrapNodes.map((peer) => ({
+				...peer,
+				id: randomNodeId(),
+			}));
+		}
+
+		for (let round = 0; round < DHT_LOOKUP_ROUNDS; round++) {
+			const batch = frontier
+				.filter((node) => !queried.has(peerKey(node)))
+				.slice(0, DHT_ALPHA);
+			if (batch.length === 0) break;
+			for (const node of batch) queried.add(peerKey(node));
+			const responses = await Promise.allSettled(
+				batch.map((node) => this.getPeersFromNode(node, infoHash)),
+			);
+			for (const response of responses) {
+				if (response.status !== "fulfilled") continue;
+				for (const peer of response.value.peers) {
+					if (isUsablePeer(peer)) peers.set(peerKey(peer), peer);
+				}
+				this.routingTable.addMany(response.value.nodes);
+			}
+			frontier = this.routingTable.closest(infoHash, DHT_ALPHA);
+			if (peers.size > 0) break;
+		}
+		this.save();
+		return [...peers.values()];
+	}
+
+	async announcePeer(infoHash: Uint8Array, port: number): Promise<void> {
+		const closest = this.routingTable.closest(infoHash, DHT_ALPHA);
+		await Promise.allSettled(
+			closest.map(async (node) => {
+				const result = await this.getPeersFromNode(node, infoHash);
+				this.routingTable.addMany(result.nodes);
+				if (!result.token) return;
+				await this.query(node, "announce_peer", {
+					id: this.nodeId,
+					info_hash: infoHash,
+					port,
+					token: result.token,
+					implied_port: 0,
+				});
+			}),
+		);
+		this.save();
+	}
+
+	close(): void {
+		for (const pending of this.pending.values()) {
+			this.scheduler.clearTimeout(pending.timer);
+			pending.reject(new Error("DHT stopped"));
+		}
+		this.pending.clear();
+		this.save();
+		this.transport.close();
+	}
+
+	private async findNode(peer: PeerInfo, target: Uint8Array): Promise<void> {
+		const message = await this.query(peer, "find_node", {
+			id: this.nodeId,
+			target,
+		});
+		if (message.type !== "response" || !message.response) return;
+		const id = getResponseId(message.response);
+		if (id) this.routingTable.add({ ...peer, id });
+		this.routingTable.addMany(getResponseNodes(message.response));
+	}
+
+	private async getPeersFromNode(
+		node: PeerInfo,
+		infoHash: Uint8Array,
+	): Promise<{
+		peers: PeerInfo[];
+		nodes: DhtNode[];
+		token: Uint8Array | null;
+	}> {
+		const message = await this.query(node, "get_peers", {
+			id: this.nodeId,
+			info_hash: infoHash,
+		});
+		if (message.type !== "response" || !message.response) {
+			return { peers: [], nodes: [], token: null };
+		}
+		const id = getResponseId(message.response);
+		if (id) this.routingTable.add({ ...node, id });
+		return {
+			peers: getResponsePeers(message.response),
+			nodes: getResponseNodes(message.response),
+			token: getResponseToken(message.response),
+		};
+	}
+
+	private query(
+		peer: PeerInfo,
+		query: "find_node" | "get_peers" | "announce_peer" | "ping",
+		args: Record<string, BencodeValue>,
+	): Promise<DhtMessage> {
+		const tid = transactionId();
+		const key = transactionKey(tid);
+		const data = encodeDhtQuery(query, args, tid);
+		return new Promise((resolve, reject) => {
+			const timer = this.scheduler.setTimeout(() => {
+				this.pending.delete(key);
+				reject(new Error("DHT query timeout"));
+			}, DHT_TIMEOUT_MS);
+			this.pending.set(key, { resolve, reject, timer });
+			void this.transport
+				.send(data, peer.port, peer.ip)
+				.catch((err: unknown) => {
+					this.pending.delete(key);
+					this.scheduler.clearTimeout(timer);
+					reject(err instanceof Error ? err : new Error(String(err)));
+				});
+		});
+	}
+
+	private onMessage(data: Uint8Array, rinfo: RemoteInfo): void {
+		let message: DhtMessage;
+		try {
+			message = decodeDhtMessage(data);
+		} catch {
+			return;
+		}
+		if (message.type === "query") {
+			void this.handleQuery(message, rinfo);
+			return;
+		}
+		const key = transactionKey(message.transactionId);
+		const pending = this.pending.get(key);
+		if (!pending) return;
+		this.pending.delete(key);
+		this.scheduler.clearTimeout(pending.timer);
+		pending.resolve(message);
+	}
+
+	private async handleQuery(
+		message: DhtMessage,
+		rinfo: RemoteInfo,
+	): Promise<void> {
+		if (!message.query) return;
+		const id = message.args?.id;
+		if (id instanceof Uint8Array) {
+			this.routingTable.add({ id, ip: rinfo.address, port: rinfo.port });
+		}
+		if (message.query === "ping") {
+			await this.transport.send(
+				encodeDhtResponse(message.transactionId, { id: this.nodeId }),
+				rinfo.port,
+				rinfo.address,
+			);
+			return;
+		}
+		if (message.query === "find_node" || message.query === "get_peers") {
+			const target =
+				message.query === "find_node" &&
+				message.args?.target instanceof Uint8Array
+					? message.args.target
+					: message.args?.info_hash instanceof Uint8Array
+						? message.args.info_hash
+						: this.nodeId;
+			await this.transport.send(
+				encodeDhtResponse(message.transactionId, {
+					id: this.nodeId,
+					nodes: compactNodes(this.routingTable.closest(target)),
+					token: stringBytes("tt"),
+				}),
+				rinfo.port,
+				rinfo.address,
+			);
+		}
+	}
+
+	private save(): void {
+		if (!this.persist) return;
+		writeDhtState(this.nodeId, this.routingTable.snapshot());
+	}
+}
+
+class DgramTransport implements UdpTransport {
+	private socket: Socket | null = null;
+
+	async bind(port: number): Promise<number> {
+		this.socket = createSocket("udp4");
+		return new Promise((resolve, reject) => {
+			const socket = this.socket;
+			if (!socket) {
+				reject(new Error("DHT socket missing"));
+				return;
+			}
+			socket.once("error", reject);
+			socket.once("listening", () => {
+				socket.removeListener("error", reject);
+				const address = socket.address();
+				resolve(typeof address === "object" ? address.port : port);
+			});
+			socket.bind(port);
+		});
+	}
+
+	onMessage(cb: (data: Uint8Array, rinfo: RemoteInfo) => void): void {
+		this.socket?.on("message", (data, rinfo) =>
+			cb(new Uint8Array(data), rinfo),
+		);
+	}
+
+	send(data: Uint8Array, port: number, host: string): Promise<void> {
+		return new Promise((resolve, reject) => {
+			this.socket?.send(data, port, host, (err) => {
+				if (err) reject(err);
+				else resolve();
+			});
+		});
+	}
+
+	close(): void {
+		this.socket?.close();
+		this.socket = null;
+	}
+}
+
+interface PersistedDhtState {
+	nodeId: Uint8Array;
+	nodes: DhtNode[];
+}
+
+function readDhtState(): PersistedDhtState | null {
+	try {
+		const path = dhtStatePath();
+		if (!existsSync(path)) return null;
+		const raw = JSON.parse(readFileSync(path, "utf-8")) as {
+			nodeId?: string;
+			nodes?: Array<{ id?: string; ip?: string; port?: number }>;
+		};
+		if (!raw.nodeId) return null;
+		return {
+			nodeId: nodeIdFromHex(raw.nodeId),
+			nodes: (raw.nodes ?? []).flatMap((node) => {
+				if (!node.id || !node.ip || typeof node.port !== "number") return [];
+				return [{ id: nodeIdFromHex(node.id), ip: node.ip, port: node.port }];
+			}),
+		};
+	} catch {
+		return null;
+	}
+}
+
+function writeDhtState(nodeId: Uint8Array, nodes: DhtNode[]): void {
+	const path = dhtStatePath();
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(
+		path,
+		JSON.stringify(
+			{
+				nodeId: nodeIdHex(nodeId),
+				nodes: nodes.map((node) => ({
+					id: nodeIdHex(node.id),
+					ip: node.ip,
+					port: node.port,
+				})),
+			},
+			null,
+			2,
+		),
+	);
+}
+
+function dhtStatePath(): string {
+	return join(getDataDir(), DHT_STATE_FILE);
+}

--- a/src/torrent/dht/protocol.ts
+++ b/src/torrent/dht/protocol.ts
@@ -1,0 +1,225 @@
+import type { BencodeValue } from "../parser.ts";
+import { decode, encode } from "../parser.ts";
+import type { PeerInfo } from "../types.ts";
+
+const TEXT_DECODER = new TextDecoder();
+const TEXT_ENCODER = new TextEncoder();
+
+export const DHT_K = 8;
+export const DHT_NODE_ID_LENGTH = 20;
+export const DEFAULT_BOOTSTRAP_NODES: PeerInfo[] = [
+	{ ip: "router.bittorrent.com", port: 6881 },
+	{ ip: "router.utorrent.com", port: 6881 },
+	{ ip: "dht.transmissionbt.com", port: 6881 },
+];
+
+export interface DhtNode extends PeerInfo {
+	id: Uint8Array;
+}
+
+export type DhtQueryName = "ping" | "find_node" | "get_peers" | "announce_peer";
+
+export interface DhtMessage {
+	transactionId: Uint8Array;
+	type: "query" | "response" | "error";
+	query?: DhtQueryName;
+	args?: Record<string, BencodeValue>;
+	response?: Record<string, BencodeValue>;
+	error?: { code: number; message: string };
+}
+
+export function randomNodeId(): Uint8Array {
+	return crypto.getRandomValues(new Uint8Array(DHT_NODE_ID_LENGTH));
+}
+
+export function nodeIdHex(id: Uint8Array): string {
+	return [...id].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export function nodeIdFromHex(hex: string): Uint8Array {
+	if (!/^[0-9a-fA-F]{40}$/.test(hex)) throw new Error("Invalid DHT node id");
+	const out = new Uint8Array(20);
+	for (let i = 0; i < out.length; i++) {
+		out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+	}
+	return out;
+}
+
+export function transactionId(): Uint8Array {
+	return crypto.getRandomValues(new Uint8Array(2));
+}
+
+export function transactionKey(id: Uint8Array): string {
+	return TEXT_DECODER.decode(id);
+}
+
+export function compactPeers(peers: PeerInfo[]): Uint8Array {
+	const out = new Uint8Array(peers.length * 6);
+	let offset = 0;
+	for (const peer of peers) {
+		const parts = peer.ip.split(".").map((part) => Number(part));
+		if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part))) {
+			throw new Error(`Cannot compact non-IPv4 peer: ${peer.ip}`);
+		}
+		out.set(parts, offset);
+		out[offset + 4] = (peer.port >>> 8) & 0xff;
+		out[offset + 5] = peer.port & 0xff;
+		offset += 6;
+	}
+	return out;
+}
+
+export function parseCompactPeers(data: Uint8Array): PeerInfo[] {
+	const peers: PeerInfo[] = [];
+	for (let offset = 0; offset + 6 <= data.length; offset += 6) {
+		const ip = `${data[offset] ?? 0}.${data[offset + 1] ?? 0}.${data[offset + 2] ?? 0}.${data[offset + 3] ?? 0}`;
+		const port = ((data[offset + 4] ?? 0) << 8) | (data[offset + 5] ?? 0);
+		if (port > 0) peers.push({ ip, port });
+	}
+	return peers;
+}
+
+export function compactNodes(nodes: DhtNode[]): Uint8Array {
+	const out = new Uint8Array(nodes.length * 26);
+	let offset = 0;
+	for (const node of nodes) {
+		if (node.id.length !== DHT_NODE_ID_LENGTH) {
+			throw new Error("DHT node id must be 20 bytes");
+		}
+		out.set(node.id, offset);
+		out.set(compactPeers([{ ip: node.ip, port: node.port }]), offset + 20);
+		offset += 26;
+	}
+	return out;
+}
+
+export function parseCompactNodes(data: Uint8Array): DhtNode[] {
+	const nodes: DhtNode[] = [];
+	for (let offset = 0; offset + 26 <= data.length; offset += 26) {
+		const id = data.slice(offset, offset + 20);
+		const [peer] = parseCompactPeers(data.slice(offset + 20, offset + 26));
+		if (peer) nodes.push({ ...peer, id });
+	}
+	return nodes;
+}
+
+export function encodeDhtQuery(
+	query: DhtQueryName,
+	args: Record<string, BencodeValue>,
+	id = transactionId(),
+): Uint8Array {
+	return encode({
+		t: id,
+		y: "q",
+		q: query,
+		a: args,
+	});
+}
+
+export function encodeDhtResponse(
+	id: Uint8Array,
+	response: Record<string, BencodeValue>,
+): Uint8Array {
+	return encode({ t: id, y: "r", r: response });
+}
+
+export function decodeDhtMessage(data: Uint8Array): DhtMessage {
+	const decoded = decode(data);
+	if (!isDict(decoded)) throw new Error("Invalid DHT message");
+	const transactionRaw = decoded.t;
+	const typeRaw = decoded.y;
+	if (!(transactionRaw instanceof Uint8Array)) {
+		throw new Error("DHT message missing transaction id");
+	}
+	const type = bytesToString(typeRaw);
+	if (type === "q") {
+		const query = bytesToString(decoded.q);
+		if (!isDhtQuery(query) || !isDict(decoded.a)) {
+			throw new Error("Invalid DHT query");
+		}
+		return {
+			transactionId: transactionRaw,
+			type: "query",
+			query,
+			args: decoded.a,
+		};
+	}
+	if (type === "r") {
+		if (!isDict(decoded.r)) throw new Error("Invalid DHT response");
+		return {
+			transactionId: transactionRaw,
+			type: "response",
+			response: decoded.r,
+		};
+	}
+	if (type === "e") {
+		const error = Array.isArray(decoded.e) ? decoded.e : [];
+		const code = typeof error[0] === "number" ? error[0] : 0;
+		return {
+			transactionId: transactionRaw,
+			type: "error",
+			error: { code, message: bytesToString(error[1]) ?? "DHT error" },
+		};
+	}
+	throw new Error("Unknown DHT message type");
+}
+
+export function getResponseId(
+	response: Record<string, BencodeValue>,
+): Uint8Array | null {
+	return response.id instanceof Uint8Array ? response.id : null;
+}
+
+export function getResponseToken(
+	response: Record<string, BencodeValue>,
+): Uint8Array | null {
+	return response.token instanceof Uint8Array ? response.token : null;
+}
+
+export function getResponsePeers(
+	response: Record<string, BencodeValue>,
+): PeerInfo[] {
+	const values = response.values;
+	if (!Array.isArray(values)) return [];
+	return values.flatMap((value) =>
+		value instanceof Uint8Array ? parseCompactPeers(value) : [],
+	);
+}
+
+export function getResponseNodes(
+	response: Record<string, BencodeValue>,
+): DhtNode[] {
+	return response.nodes instanceof Uint8Array
+		? parseCompactNodes(response.nodes)
+		: [];
+}
+
+export function stringBytes(value: string): Uint8Array {
+	return TEXT_ENCODER.encode(value);
+}
+
+function isDict(
+	value: BencodeValue | undefined,
+): value is Record<string, BencodeValue> {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!Array.isArray(value) &&
+		!(value instanceof Uint8Array)
+	);
+}
+
+function bytesToString(value: BencodeValue | undefined): string | undefined {
+	if (value instanceof Uint8Array) return TEXT_DECODER.decode(value);
+	if (typeof value === "string") return value;
+	return undefined;
+}
+
+function isDhtQuery(value: string | undefined): value is DhtQueryName {
+	return (
+		value === "ping" ||
+		value === "find_node" ||
+		value === "get_peers" ||
+		value === "announce_peer"
+	);
+}

--- a/src/torrent/dht/routing.ts
+++ b/src/torrent/dht/routing.ts
@@ -1,0 +1,98 @@
+import type { PeerInfo } from "../types.ts";
+import {
+	DHT_K,
+	DHT_NODE_ID_LENGTH,
+	type DhtNode,
+	nodeIdHex,
+} from "./protocol.ts";
+
+export class DhtRoutingTable {
+	private readonly nodes = new Map<string, DhtNode>();
+
+	constructor(private readonly ownId: Uint8Array) {
+		if (ownId.length !== DHT_NODE_ID_LENGTH) {
+			throw new Error("DHT node id must be 20 bytes");
+		}
+	}
+
+	add(node: DhtNode): void {
+		if (node.id.length !== DHT_NODE_ID_LENGTH) return;
+		if (sameBytes(node.id, this.ownId)) return;
+		if (!isUsablePeer(node)) return;
+		const key = peerKey(node);
+		if (this.nodes.has(key)) {
+			this.nodes.set(key, node);
+			return;
+		}
+		if (this.nodes.size < DHT_K * 32) {
+			this.nodes.set(key, node);
+			return;
+		}
+		const farthest = this.closest(this.ownId).at(-1);
+		if (!farthest) return;
+		if (compareDistance(node.id, farthest.id, this.ownId) < 0) {
+			this.nodes.delete(peerKey(farthest));
+			this.nodes.set(key, node);
+		}
+	}
+
+	addMany(nodes: DhtNode[]): void {
+		for (const node of nodes) this.add(node);
+	}
+
+	closest(target: Uint8Array, count = DHT_K): DhtNode[] {
+		return [...this.nodes.values()]
+			.sort((a, b) => compareDistance(a.id, b.id, target))
+			.slice(0, count);
+	}
+
+	peers(): PeerInfo[] {
+		return [...this.nodes.values()].map(({ ip, port }) => ({ ip, port }));
+	}
+
+	snapshot(): DhtNode[] {
+		return [...this.nodes.values()];
+	}
+
+	get size(): number {
+		return this.nodes.size;
+	}
+}
+
+export function compareDistance(
+	left: Uint8Array,
+	right: Uint8Array,
+	target: Uint8Array,
+): number {
+	for (let i = 0; i < DHT_NODE_ID_LENGTH; i++) {
+		const leftDistance = (left[i] ?? 0) ^ (target[i] ?? 0);
+		const rightDistance = (right[i] ?? 0) ^ (target[i] ?? 0);
+		if (leftDistance !== rightDistance) return leftDistance - rightDistance;
+	}
+	return 0;
+}
+
+export function peerKey(peer: PeerInfo): string {
+	return `${peer.ip}:${peer.port}`;
+}
+
+export function nodeKey(node: DhtNode): string {
+	return `${nodeIdHex(node.id)}@${peerKey(node)}`;
+}
+
+export function isUsablePeer(peer: PeerInfo): boolean {
+	return (
+		peer.port > 0 &&
+		peer.port <= 65535 &&
+		peer.ip.length > 0 &&
+		peer.ip !== "0.0.0.0"
+	);
+}
+
+function sameBytes(left: Uint8Array, right: Uint8Array): boolean {
+	if (left.length !== right.length) return false;
+	for (let i = 0; i < left.length; i++) {
+		if (left[i] !== right[i]) return false;
+	}
+	return true;
+}

--- a/src/torrent/discovery/coordinator.ts
+++ b/src/torrent/discovery/coordinator.ts
@@ -1,0 +1,231 @@
+import { DhtClient } from "../dht/node.ts";
+import { DEFAULT_BOOTSTRAP_NODES } from "../dht/protocol.ts";
+import type { TorrentMetadata } from "../metadata.ts";
+import type { PeerConnection } from "../peer/connection.ts";
+import type { UtPexMessage } from "../peer/extension.ts";
+import type { PeerManager } from "../peer/manager.ts";
+import { TrackerCoordinator } from "../tracker/coordinator.ts";
+import type {
+	PeerInfo,
+	TrackerAnnounceRequest,
+	TrackerResponse,
+} from "../types.ts";
+
+const PEX_INTERVAL_MS = 60_000;
+
+interface DiscoverySnapshot {
+	downloaded: number;
+	uploaded: number;
+	left: number;
+}
+
+interface DiscoveryScheduler {
+	setInterval(fn: () => void, delayMs: number): unknown;
+	clearInterval(handle: unknown): void;
+}
+
+export interface DiscoveryCoordinatorOptions {
+	port?: number;
+	numwant?: number;
+	getSnapshot: () => DiscoverySnapshot;
+	onPeers: (peers: PeerInfo[], source: "tracker" | "dht" | "pex") => void;
+	announceTracker?: (
+		url: string,
+		metadata: TorrentMetadata,
+		request: TrackerAnnounceRequest,
+	) => Promise<TrackerResponse>;
+	dht?: DhtClient | null;
+	scheduler?: DiscoveryScheduler;
+}
+
+export class DiscoveryCoordinator {
+	private readonly tracker: TrackerCoordinator;
+	private readonly dht: DhtClient | null;
+	private readonly pex: PexCoordinator | null;
+	private readonly scheduler: DiscoveryScheduler;
+	private dhtRefreshTimer: unknown | null = null;
+	private dhtStarted = false;
+	private stopped = false;
+
+	constructor(
+		private readonly metadata: TorrentMetadata,
+		private readonly manager: PeerManager,
+		private readonly options: DiscoveryCoordinatorOptions,
+	) {
+		this.tracker = new TrackerCoordinator(metadata, {
+			port: options.port,
+			numwant: options.numwant,
+			getSnapshot: options.getSnapshot,
+			announceTracker: options.announceTracker,
+			onPeers: (peers) => options.onPeers(peers, "tracker"),
+		});
+		this.dht = metadata.private
+			? null
+			: (options.dht ??
+				new DhtClient({
+					bootstrapNodes: [...metadata.nodes, ...DEFAULT_BOOTSTRAP_NODES],
+				}));
+		this.pex = metadata.private
+			? null
+			: new PexCoordinator(manager, (peers) => options.onPeers(peers, "pex"));
+		this.scheduler = options.scheduler ?? {
+			setInterval: (fn, delayMs) => setInterval(fn, delayMs),
+			clearInterval: (handle) =>
+				clearInterval(handle as ReturnType<typeof setInterval>),
+		};
+	}
+
+	async start(): Promise<void> {
+		if (this.stopped) return;
+		this.tracker.start();
+		await this.startDht();
+		this.pex?.start();
+	}
+
+	refreshNow(): void {
+		if (this.stopped) return;
+		this.tracker.refreshNow();
+		void this.refreshDht();
+	}
+
+	markCompleted(): void {
+		this.tracker.markCompleted();
+	}
+
+	async stop(): Promise<void> {
+		if (this.stopped) return;
+		this.stopped = true;
+		this.pex?.stop();
+		if (this.dhtRefreshTimer) {
+			this.scheduler.clearInterval(this.dhtRefreshTimer);
+			this.dhtRefreshTimer = null;
+		}
+		this.dht?.close();
+		await this.tracker.stop();
+	}
+
+	private async startDht(): Promise<void> {
+		if (!this.dht) return;
+		try {
+			await this.dht.start(this.manager.listenPort());
+			this.dhtStarted = true;
+		} catch {
+			return;
+		}
+		this.manager.on("dhtPort", (peer: PeerInfo) => {
+			this.dht?.routingTable.add({ ...peer, id: new Uint8Array(20) });
+		});
+		for (const conn of this.manager.connections.values()) {
+			conn.sendDhtPort(this.manager.listenPort());
+		}
+		await this.refreshDht();
+		this.dhtRefreshTimer = this.scheduler.setInterval(() => {
+			void this.refreshDht();
+		}, 15 * 60_000);
+	}
+
+	private async refreshDht(): Promise<void> {
+		if (!this.dht || !this.dhtStarted || this.stopped) return;
+		const peers = await this.dht
+			.getPeers(this.metadata.infoHash)
+			.catch(() => []);
+		if (peers.length > 0) this.options.onPeers(peers, "dht");
+		if (this.options.getSnapshot().left === 0) {
+			await this.dht
+				.announcePeer(this.metadata.infoHash, this.manager.listenPort())
+				.catch(() => undefined);
+		}
+	}
+}
+
+class PexCoordinator {
+	private added = new Map<string, PeerInfo>();
+	private dropped = new Map<string, PeerInfo>();
+	private timer: unknown | null = null;
+	private stopped = false;
+
+	constructor(
+		private readonly manager: PeerManager,
+		private readonly onPeers: (peers: PeerInfo[]) => void,
+		private readonly scheduler: DiscoveryScheduler = {
+			setInterval: (fn, delayMs) => setInterval(fn, delayMs),
+			clearInterval: (handle) =>
+				clearInterval(handle as ReturnType<typeof setInterval>),
+		},
+	) {}
+
+	start(): void {
+		this.manager.on("peerAdded", this.onPeerAdded);
+		this.manager.on("peerRemoved", this.onPeerRemoved);
+		for (const conn of this.manager.connections.values()) this.wirePeer(conn);
+		this.timer = this.scheduler.setInterval(
+			() => this.flush(),
+			PEX_INTERVAL_MS,
+		);
+	}
+
+	stop(): void {
+		this.stopped = true;
+		this.manager.off("peerAdded", this.onPeerAdded);
+		this.manager.off("peerRemoved", this.onPeerRemoved);
+		if (this.timer) this.scheduler.clearInterval(this.timer);
+		this.timer = null;
+	}
+
+	private readonly onPeerAdded = (conn: PeerConnection): void => {
+		const peer = { ip: conn.address, port: conn.port };
+		this.added.set(peerKey(peer), peer);
+		this.dropped.delete(peerKey(peer));
+		this.wirePeer(conn);
+	};
+
+	private readonly onPeerRemoved = (conn: PeerConnection): void => {
+		const peer = { ip: conn.address, port: conn.port };
+		this.added.delete(peerKey(peer));
+		this.dropped.set(peerKey(peer), peer);
+	};
+
+	private wirePeer(conn: PeerConnection): void {
+		conn.on("extensionHandshake", () => {
+			if (this.stopped) return;
+			if (!conn.peerExtensions.has("ut_pex")) return;
+			conn.sendUtPex({
+				added: [...this.manager.connections.values()]
+					.filter((peer) => peer !== conn)
+					.map((peer) => ({ ip: peer.address, port: peer.port })),
+				dropped: [],
+			});
+		});
+		conn.on("utPex", (message: UtPexMessage) => {
+			const peers = message.added.filter(
+				(peer) => !this.manager.hasPeer(peer) && isIPv4Peer(peer),
+			);
+			if (peers.length > 0) this.onPeers(peers);
+		});
+	}
+
+	private flush(): void {
+		const message: UtPexMessage = {
+			added: [...this.added.values()],
+			dropped: [...this.dropped.values()],
+		};
+		if (message.added.length === 0 && message.dropped.length === 0) return;
+		for (const conn of this.manager.connections.values()) {
+			if (conn.peerExtensions.has("ut_pex")) conn.sendUtPex(message);
+		}
+		this.added.clear();
+		this.dropped.clear();
+	}
+}
+
+function peerKey(peer: PeerInfo): string {
+	return `${peer.ip}:${peer.port}`;
+}
+
+function isIPv4Peer(peer: PeerInfo): boolean {
+	return (
+		/^\d{1,3}(\.\d{1,3}){3}$/.test(peer.ip) &&
+		peer.port > 0 &&
+		peer.port <= 65535
+	);
+}

--- a/src/torrent/downloader.ts
+++ b/src/torrent/downloader.ts
@@ -292,6 +292,7 @@ export class Downloader extends EventEmitter {
 
 			if (strikes >= CORRUPT_STRIKE_LIMIT) {
 				this.bannedPeers.add(key);
+				this.manager.ban({ ip: conn.address, port: conn.port });
 				conn.suppressDisconnect = true;
 				conn.destroy();
 			}
@@ -407,7 +408,11 @@ export class Downloader extends EventEmitter {
 				const begin = Number(reqKey.slice(prefix.length));
 				const blockIdx = Math.floor(begin / BLOCK_SIZE);
 				if (sendCancel && peer) {
-					peer.sendCancel(pieceIndex, begin, this.blockLength(pieceIndex, blockIdx));
+					peer.sendCancel(
+						pieceIndex,
+						begin,
+						this.blockLength(pieceIndex, blockIdx),
+					);
 				}
 			}
 		}

--- a/src/torrent/magnet-resolver.ts
+++ b/src/torrent/magnet-resolver.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { DhtClient } from "./dht/node.ts";
 import { type MagnetInfo, parseMagnetUri } from "./magnet.ts";
 import { TorrentMetadata } from "./metadata.ts";
 import {
@@ -28,6 +29,7 @@ export interface MagnetResolveProgress {
 
 export interface ResolveMagnetOptions {
 	onProgress?: (progress: MagnetResolveProgress) => void;
+	dht?: DhtClient | null;
 }
 
 export interface ResolveMagnetResult {
@@ -49,15 +51,13 @@ export async function resolveMagnetToTorrent(
 		};
 	}
 
-	const peers = await discoverMagnetPeers(magnet);
+	const peers = await discoverMagnetPeers(magnet, options.dht);
 	options.onProgress?.({
 		status: peers.length > 0 ? "metadata" : "stalled",
 		peers: peers.length,
 	});
 	if (peers.length === 0) {
-		throw new Error(
-			"No peers found for magnet metadata; DHT support is planned for phase 13",
-		);
+		throw new Error("No peers found for magnet metadata");
 	}
 
 	const infoBytes = await fetchMetadataFromPeers(magnet, peers, options);
@@ -71,7 +71,10 @@ export async function resolveMagnetToTorrent(
 	return { magnet, torrentPath, fromCache: false };
 }
 
-async function discoverMagnetPeers(magnet: MagnetInfo): Promise<PeerInfo[]> {
+async function discoverMagnetPeers(
+	magnet: MagnetInfo,
+	dhtOverride?: DhtClient | null,
+): Promise<PeerInfo[]> {
 	const target: TrackerAnnounceTarget = {
 		infoHash: magnet.infoHash,
 		totalSize: 0,
@@ -85,15 +88,34 @@ async function discoverMagnetPeers(magnet: MagnetInfo): Promise<PeerInfo[]> {
 					}))
 				).peers
 			: [];
+	const ownsDht = dhtOverride === undefined;
+	const dht = ownsDht ? new DhtClient() : dhtOverride;
+	const dhtPeers =
+		dht && (magnet.trackers.length === 0 || trackerPeers.length === 0)
+			? await discoverMagnetPeersFromDht(dht, magnet.infoHash)
+			: [];
+	if (ownsDht) dht?.close();
 	const seen = new Set<string>();
 	const peers: PeerInfo[] = [];
-	for (const peer of [...magnet.peers, ...trackerPeers]) {
+	for (const peer of [...magnet.peers, ...trackerPeers, ...dhtPeers]) {
 		const key = `${peer.ip}:${peer.port}`;
 		if (seen.has(key)) continue;
 		seen.add(key);
 		peers.push(peer);
 	}
 	return peers;
+}
+
+async function discoverMagnetPeersFromDht(
+	dht: DhtClient,
+	infoHash: Uint8Array,
+): Promise<PeerInfo[]> {
+	try {
+		await dht.start();
+		return await dht.getPeers(infoHash);
+	} catch {
+		return [];
+	}
 }
 
 async function announceResolvedMagnet(

--- a/src/torrent/metadata.ts
+++ b/src/torrent/metadata.ts
@@ -20,6 +20,8 @@ export class TorrentMetadata {
 	readonly infoHash: Uint8Array;
 	readonly infoBytes: Uint8Array;
 	readonly announceList: string[][];
+	readonly private: boolean;
+	readonly nodes: Array<{ ip: string; port: number }>;
 
 	constructor(
 		decoded: { [key: string]: BencodeValue },
@@ -35,6 +37,7 @@ export class TorrentMetadata {
 			throw new Error("Missing or invalid info dict");
 		}
 		const infoDict = info as { [key: string]: BencodeValue };
+		this.private = infoDict.private === 1;
 
 		// name
 		const nameRaw = infoDict.name;
@@ -135,6 +138,8 @@ export class TorrentMetadata {
 						: null;
 			this.announceList = announceStr ? [[announceStr]] : [];
 		}
+
+		this.nodes = parseDhtNodes(decoded.nodes);
 	}
 
 	formatSize(): string {
@@ -202,4 +207,25 @@ export class TorrentMetadata {
 			`${this.name}   ${this.formatSize()}   ${this.pieceCount} × ${this.formatPieceLength()}   ${trackerParts || "no trackers"}`,
 		);
 	}
+}
+
+function parseDhtNodes(
+	value: BencodeValue | undefined,
+): Array<{ ip: string; port: number }> {
+	if (!Array.isArray(value)) return [];
+	const nodes: Array<{ ip: string; port: number }> = [];
+	for (const entry of value) {
+		if (!Array.isArray(entry) || entry.length < 2) continue;
+		const hostRaw = entry[0];
+		const port = entry[1];
+		const ip =
+			hostRaw instanceof Uint8Array
+				? TEXT_DECODER.decode(hostRaw)
+				: typeof hostRaw === "string"
+					? hostRaw
+					: null;
+		if (!ip || typeof port !== "number" || port <= 0 || port > 65535) continue;
+		nodes.push({ ip, port });
+	}
+	return nodes;
 }

--- a/src/torrent/peer/connection.ts
+++ b/src/torrent/peer/connection.ts
@@ -7,15 +7,19 @@ import {
 	decodeExtendedMessage,
 	decodeExtensionHandshake,
 	decodeUtMetadataMessage,
+	decodeUtPexMessage,
 	EXT_HANDSHAKE_ID,
 	encodeExtendedMessage,
 	encodeExtensionHandshake,
 	encodeUtMetadataData,
 	encodeUtMetadataReject,
 	encodeUtMetadataRequest,
+	encodeUtPexMessage,
 	LOCAL_UT_METADATA_ID,
+	LOCAL_UT_PEX_ID,
 	METADATA_BLOCK_SIZE,
 	supportsExtensionProtocol,
+	type UtPexMessage,
 } from "./extension.ts";
 import { buildHandshake, HANDSHAKE_LEN, parseHandshake } from "./handshake.ts";
 import { MessageBuffer } from "./message-buffer.ts";
@@ -24,10 +28,12 @@ import {
 	decodeHave,
 	decode as decodeMsg,
 	decodePiece,
+	decodePort,
 	decodeRequest,
 	encodeCancel,
 	encodeHave,
 	encode as encodeMsg,
+	encodePort,
 	encodeRequest,
 	MSG,
 } from "./protocol.ts";
@@ -253,6 +259,9 @@ export class PeerConnection extends EventEmitter {
 						this.emit("request", req.index, req.begin, req.length);
 					}
 					break;
+				case MSG.PORT:
+					if (msg.payload) this.emit("dhtPort", decodePort(msg.payload));
+					break;
 				case MSG.EXTENDED:
 					if (msg.payload) this.onExtendedMessage(msg.payload);
 					break;
@@ -279,6 +288,10 @@ export class PeerConnection extends EventEmitter {
 				} else {
 					this.emit("utMetadata", msg);
 				}
+				return;
+			}
+			if (extended.extensionId === LOCAL_UT_PEX_ID) {
+				this.emit("utPex", decodeUtPexMessage(extended.payload));
 			}
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);
@@ -370,6 +383,21 @@ export class PeerConnection extends EventEmitter {
 				payload: encodeExtensionHandshake({
 					metadataSize: this.localMetadata?.length,
 				}),
+			}),
+		);
+	}
+
+	sendDhtPort(port: number): void {
+		this.write(encodePort(port));
+	}
+
+	sendUtPex(message: UtPexMessage): void {
+		const id = this.peerExtensions.get("ut_pex");
+		if (!id) return;
+		this.write(
+			encodeMsg({
+				type: MSG.EXTENDED,
+				payload: encodeExtendedMessage(id, encodeUtPexMessage(message)),
 			}),
 		);
 	}

--- a/src/torrent/peer/extension.ts
+++ b/src/torrent/peer/extension.ts
@@ -4,6 +4,7 @@ import { decode, encode } from "../parser.ts";
 export const EXTENDED_MESSAGE_ID = 20;
 export const EXT_HANDSHAKE_ID = 0;
 export const LOCAL_UT_METADATA_ID = 1;
+export const LOCAL_UT_PEX_ID = 2;
 export const EXTENSION_PROTOCOL_RESERVED_BYTE = 5;
 export const EXTENSION_PROTOCOL_RESERVED_MASK = 0x10;
 export const METADATA_BLOCK_SIZE = 16 * 1024;
@@ -19,6 +20,11 @@ export type UtMetadataMessage =
 	| { msgType: 0; piece: number }
 	| { msgType: 1; piece: number; totalSize: number; data: Uint8Array }
 	| { msgType: 2; piece: number };
+
+export interface UtPexMessage {
+	added: Array<{ ip: string; port: number }>;
+	dropped: Array<{ ip: string; port: number }>;
+}
 
 export function supportsExtensionProtocol(reserved: Uint8Array): boolean {
 	return (
@@ -50,13 +56,22 @@ export function decodeExtendedMessage(payload: Uint8Array): {
 }
 
 export function encodeExtensionHandshake(
-	options: { metadataSize?: number; utMetadataId?: number } = {},
+	options: {
+		metadataSize?: number;
+		utMetadataId?: number;
+		utPexId?: number;
+		pex?: boolean;
+	} = {},
 ): Uint8Array {
 	const body: { [key: string]: BencodeValue } = {
 		m: {
 			ut_metadata: options.utMetadataId ?? LOCAL_UT_METADATA_ID,
 		},
 	};
+	if (options.pex ?? true) {
+		(body.m as { [key: string]: BencodeValue }).ut_pex =
+			options.utPexId ?? LOCAL_UT_PEX_ID;
+	}
 	if (options.metadataSize !== undefined)
 		body.metadata_size = options.metadataSize;
 	return encodeExtendedMessage(EXT_HANDSHAKE_ID, encode(body));
@@ -145,6 +160,68 @@ export function decodeUtMetadataMessage(
 		};
 	}
 	throw new Error(`Unsupported ut_metadata msg_type: ${msgType}`);
+}
+
+export function encodeUtPexMessage(message: UtPexMessage): Uint8Array {
+	return encode({
+		added: encodeCompactPeers(message.added),
+		dropped: encodeCompactPeers(message.dropped),
+	});
+}
+
+export function decodeUtPexMessage(payload: Uint8Array): UtPexMessage {
+	const decoded = decode(payload);
+	if (
+		typeof decoded !== "object" ||
+		decoded === null ||
+		Array.isArray(decoded) ||
+		decoded instanceof Uint8Array
+	) {
+		throw new Error("Invalid ut_pex message");
+	}
+	return {
+		added:
+			decoded.added instanceof Uint8Array
+				? decodeCompactPeers(decoded.added)
+				: [],
+		dropped:
+			decoded.dropped instanceof Uint8Array
+				? decodeCompactPeers(decoded.dropped)
+				: [],
+	};
+}
+
+function encodeCompactPeers(
+	peers: Array<{ ip: string; port: number }>,
+): Uint8Array {
+	const bytes = new Uint8Array(peers.length * 6);
+	let offset = 0;
+	for (const peer of peers) {
+		const octets = peer.ip.split(".").map((part) => Number(part));
+		if (
+			octets.length !== 4 ||
+			octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
+		) {
+			throw new Error(`Cannot encode non-IPv4 PEX peer: ${peer.ip}`);
+		}
+		bytes.set(octets, offset);
+		bytes[offset + 4] = (peer.port >>> 8) & 0xff;
+		bytes[offset + 5] = peer.port & 0xff;
+		offset += 6;
+	}
+	return bytes;
+}
+
+function decodeCompactPeers(
+	data: Uint8Array,
+): Array<{ ip: string; port: number }> {
+	const peers: Array<{ ip: string; port: number }> = [];
+	for (let offset = 0; offset + 6 <= data.length; offset += 6) {
+		const ip = `${data[offset] ?? 0}.${data[offset + 1] ?? 0}.${data[offset + 2] ?? 0}.${data[offset + 3] ?? 0}`;
+		const port = ((data[offset + 4] ?? 0) << 8) | (data[offset + 5] ?? 0);
+		if (port > 0) peers.push({ ip, port });
+	}
+	return peers;
 }
 
 function findBencodeEnd(data: Uint8Array, index: number): number {

--- a/src/torrent/peer/manager.ts
+++ b/src/torrent/peer/manager.ts
@@ -19,6 +19,7 @@ export class PeerManager extends EventEmitter {
 	private optimisticTimer: ReturnType<typeof setInterval> | null = null;
 	private optimisticKey: string | null = null;
 	private unchokedKeys = new Set<string>();
+	private bannedPeers = new Set<string>();
 
 	constructor(metadata: TorrentMetadata, maxConnections = 50) {
 		super();
@@ -48,6 +49,7 @@ export class PeerManager extends EventEmitter {
 
 	private async connectOne(ip: string, port: number): Promise<void> {
 		const key = `${ip}:${port}`;
+		if (this.bannedPeers.has(key)) return;
 		if (this.connections.has(key)) return;
 
 		const conn = new PeerConnection(ip, port, this.infoHash, {
@@ -62,6 +64,9 @@ export class PeerManager extends EventEmitter {
 		conn.on("disconnect", () => {
 			this.connections.delete(key);
 			this.emit("peerRemoved", conn);
+		});
+		conn.on("dhtPort", (dhtPort: number) => {
+			this.emit("dhtPort", { ip: conn.address, port: dhtPort });
 		});
 
 		try {
@@ -99,6 +104,10 @@ export class PeerManager extends EventEmitter {
 				const ip = socket.remoteAddress ?? "unknown";
 				const port = socket.remotePort ?? 0;
 				const key = `${ip}:${port}`;
+				if (this.bannedPeers.has(key) || this.connections.has(key)) {
+					socket.destroy();
+					return;
+				}
 				log(
 					"peer",
 					`${key.padEnd(50)}  ok   ${result.peerId.slice(0, 8)}  (inbound)`,
@@ -114,6 +123,9 @@ export class PeerManager extends EventEmitter {
 				conn.on("disconnect", () => {
 					this.connections.delete(key);
 					this.emit("peerRemoved", conn);
+				});
+				conn.on("dhtPort", (dhtPort: number) => {
+					this.emit("dhtPort", { ip: conn.address, port: dhtPort });
 				});
 				this.connections.set(key, conn);
 				conn.adoptConnectedSocket(socket, remainder, {
@@ -234,10 +246,30 @@ export class PeerManager extends EventEmitter {
 		const seen = new Set<string>();
 		return peers.filter((p) => {
 			const k = `${p.ip}:${p.port}`;
+			if (this.bannedPeers.has(k) || this.connections.has(k)) return false;
 			if (seen.has(k)) return false;
 			seen.add(k);
 			return true;
 		});
+	}
+
+	ban(peer: PeerInfo): void {
+		const key = `${peer.ip}:${peer.port}`;
+		this.bannedPeers.add(key);
+		this.connections.get(key)?.destroy();
+	}
+
+	hasPeer(peer: PeerInfo): boolean {
+		const key = `${peer.ip}:${peer.port}`;
+		return this.connections.has(key) || this.bannedPeers.has(key);
+	}
+
+	availableSlots(): number {
+		return Math.max(0, this.maxConnections - this.connections.size);
+	}
+
+	listenPort(): number {
+		return this.listener.port;
 	}
 
 	close(): void {

--- a/src/torrent/peer/protocol.ts
+++ b/src/torrent/peer/protocol.ts
@@ -9,6 +9,7 @@ export const MSG = {
 	REQUEST: 6,
 	PIECE: 7,
 	CANCEL: 8,
+	PORT: 9,
 	EXTENDED: 20,
 } as const;
 
@@ -101,6 +102,17 @@ export function decodeRequest(payload: Uint8Array): {
 		begin: view.getUint32(4),
 		length: view.getUint32(8),
 	};
+}
+
+export function encodePort(port: number): Uint8Array {
+	const payload = new Uint8Array(2);
+	const view = new DataView(payload.buffer);
+	view.setUint16(0, port);
+	return encode({ type: MSG.PORT, payload });
+}
+
+export function decodePort(payload: Uint8Array): number {
+	return new DataView(payload.buffer, payload.byteOffset).getUint16(0);
 }
 
 export function decodePiece(payload: Uint8Array): {

--- a/tests/helpers/torrent-fixtures.ts
+++ b/tests/helpers/torrent-fixtures.ts
@@ -30,6 +30,8 @@ export function singleFileTorrentFixture(
 		pieceLength?: number;
 		announce?: string;
 		announceList?: string[][];
+		nodes?: Array<[string, number]>;
+		private?: boolean;
 	} = {},
 ): TorrentFixture {
 	const name = options.name ?? "sample.bin";
@@ -81,6 +83,8 @@ function buildTorrentDictionary(
 	options: {
 		announce?: string;
 		announceList?: string[][];
+		nodes?: Array<[string, number]>;
+		private?: boolean;
 	},
 ): { [key: string]: BencodeValue } {
 	const torrent: { [key: string]: BencodeValue } = {
@@ -89,6 +93,12 @@ function buildTorrentDictionary(
 	};
 	if (options.announceList) {
 		torrent["announce-list"] = options.announceList;
+	}
+	if (options.nodes) {
+		torrent.nodes = options.nodes;
+	}
+	if (options.private) {
+		info.private = 1;
 	}
 	return torrent;
 }

--- a/tests/torrent/dht.test.ts
+++ b/tests/torrent/dht.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import type { RemoteInfo } from "node:dgram";
+import { DhtClient } from "../../src/torrent/dht/node.ts";
+import {
+	compactNodes,
+	compactPeers,
+	type DhtNode,
+	decodeDhtMessage,
+	encodeDhtResponse,
+	nodeIdFromHex,
+	parseCompactNodes,
+	parseCompactPeers,
+} from "../../src/torrent/dht/protocol.ts";
+import { DhtRoutingTable } from "../../src/torrent/dht/routing.ts";
+
+const OWN_ID = nodeIdFromHex("0000000000000000000000000000000000000001");
+const BOOTSTRAP_ID = nodeIdFromHex("0000000000000000000000000000000000000002");
+const INFO_HASH = nodeIdFromHex("1111111111111111111111111111111111111111");
+
+describe("DHT protocol helpers", () => {
+	test("encodes and parses compact peers and nodes", () => {
+		const peers = [
+			{ ip: "127.0.0.1", port: 6881 },
+			{ ip: "10.0.0.2", port: 51413 },
+		];
+		expect(parseCompactPeers(compactPeers(peers))).toEqual(peers);
+
+		const nodes: DhtNode[] = [
+			{ id: BOOTSTRAP_ID, ip: "127.0.0.1", port: 6881 },
+		];
+		expect(parseCompactNodes(compactNodes(nodes))).toEqual(nodes);
+	});
+
+	test("decodes KRPC responses", () => {
+		const tid = new Uint8Array([1, 2]);
+		const response = decodeDhtMessage(
+			encodeDhtResponse(tid, {
+				id: BOOTSTRAP_ID,
+				values: [compactPeers([{ ip: "127.0.0.9", port: 7000 }])],
+			}),
+		);
+
+		expect(response.type).toBe("response");
+		expect(response.transactionId).toEqual(tid);
+		expect(response.response?.id).toEqual(BOOTSTRAP_ID);
+	});
+});
+
+describe("DhtRoutingTable", () => {
+	test("keeps bounded closest nodes", () => {
+		const table = new DhtRoutingTable(OWN_ID);
+		for (let i = 2; i < 100; i++) {
+			const id = new Uint8Array(20);
+			id[19] = i;
+			table.add({ id, ip: `127.0.0.${i}`, port: 6000 + i });
+		}
+
+		expect(table.size).toBeLessThanOrEqual(256);
+		expect(table.closest(INFO_HASH, 8)).toHaveLength(8);
+	});
+});
+
+describe("DhtClient", () => {
+	test("discovers peers through fake KRPC get_peers", async () => {
+		const transport = new FakeDhtTransport();
+		const client = new DhtClient({
+			nodeId: OWN_ID,
+			bootstrapNodes: [{ ip: "127.0.0.2", port: 6881 }],
+			transport,
+			persist: false,
+		});
+
+		transport.onSend = (data, port, host) => {
+			const decoded = decodeDhtMessage(data);
+			const tid = decoded.transactionId;
+			if (decoded.query === "find_node") {
+				transport.deliver(
+					encodeDhtResponse(tid, {
+						id: BOOTSTRAP_ID,
+						nodes: compactNodes([{ id: BOOTSTRAP_ID, ip: host, port }]),
+					}),
+					host,
+					port,
+				);
+			}
+			if (decoded.query === "get_peers") {
+				transport.deliver(
+					encodeDhtResponse(tid, {
+						id: BOOTSTRAP_ID,
+						token: new Uint8Array([7]),
+						values: [compactPeers([{ ip: "127.0.0.9", port: 7000 }])],
+					}),
+					host,
+					port,
+				);
+			}
+		};
+
+		await client.start(0);
+		const peers = await client.getPeers(INFO_HASH);
+
+		expect(peers).toEqual([{ ip: "127.0.0.9", port: 7000 }]);
+		client.close();
+	});
+});
+
+class FakeDhtTransport {
+	private cb: ((data: Uint8Array, rinfo: RemoteInfo) => void) | null = null;
+	onSend: ((data: Uint8Array, port: number, host: string) => void) | null =
+		null;
+
+	async bind(port: number): Promise<number> {
+		return port;
+	}
+
+	onMessage(cb: (data: Uint8Array, rinfo: RemoteInfo) => void): void {
+		this.cb = cb;
+	}
+
+	async send(data: Uint8Array, port: number, host: string): Promise<void> {
+		this.onSend?.(data, port, host);
+	}
+
+	close(): void {}
+
+	deliver(data: Uint8Array, address: string, port: number): void {
+		this.cb?.(data, {
+			address,
+			port,
+			family: "IPv4",
+			size: data.length,
+		});
+	}
+}

--- a/tests/torrent/discovery.test.ts
+++ b/tests/torrent/discovery.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import type { DhtClient } from "../../src/torrent/dht/node.ts";
+import { DiscoveryCoordinator } from "../../src/torrent/discovery/coordinator.ts";
+import type { PeerManager } from "../../src/torrent/peer/manager.ts";
+import { singleFileTorrentFixture } from "../helpers/torrent-fixtures.ts";
+
+describe("DiscoveryCoordinator", () => {
+	test("does not start DHT for private torrents", async () => {
+		const fixture = singleFileTorrentFixture({ private: true });
+		const dht = new FakeDiscoveryDht();
+		const coordinator = new DiscoveryCoordinator(
+			fixture.metadata,
+			new FakeDiscoveryPeerManager().asManager(),
+			{
+				dht: dht as unknown as DhtClient,
+				getSnapshot: () => ({ downloaded: 0, uploaded: 0, left: 1 }),
+				onPeers: () => {},
+				announceTracker: async () => ({
+					complete: 0,
+					incomplete: 0,
+					interval: 60,
+					peers: [],
+				}),
+			},
+		);
+
+		await coordinator.start();
+		await coordinator.stop();
+
+		expect(dht.started).toBe(false);
+	});
+
+	test("does not refresh DHT when startup fails", async () => {
+		const fixture = singleFileTorrentFixture();
+		const dht = new FailingDiscoveryDht();
+		const coordinator = new DiscoveryCoordinator(
+			fixture.metadata,
+			new FakeDiscoveryPeerManager().asManager(),
+			{
+				dht: dht as unknown as DhtClient,
+				getSnapshot: () => ({ downloaded: 0, uploaded: 0, left: 1 }),
+				onPeers: () => {},
+				announceTracker: async () => ({
+					complete: 0,
+					incomplete: 0,
+					interval: 60,
+					peers: [],
+				}),
+			},
+		);
+
+		await coordinator.start();
+		coordinator.refreshNow();
+		await coordinator.stop();
+
+		expect(dht.getPeerCalls).toBe(0);
+	});
+});
+
+class FakeDiscoveryDht {
+	started = false;
+
+	async start(): Promise<void> {
+		this.started = true;
+	}
+}
+
+class FailingDiscoveryDht {
+	getPeerCalls = 0;
+	readonly routingTable = {
+		add: () => {},
+	};
+
+	async start(): Promise<void> {
+		throw new Error("bind failed");
+	}
+
+	async getPeers(): Promise<[]> {
+		this.getPeerCalls++;
+		return [];
+	}
+
+	close(): void {}
+}
+
+class FakeDiscoveryPeerManager extends EventEmitter {
+	readonly connections = new Map();
+
+	listenPort(): number {
+		return 6881;
+	}
+
+	asManager(): PeerManager {
+		return this as unknown as PeerManager;
+	}
+}

--- a/tests/torrent/magnet.test.ts
+++ b/tests/torrent/magnet.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import type { DhtClient } from "../../src/torrent/dht/node.ts";
 import { parseMagnetUri } from "../../src/torrent/magnet.ts";
+import { resolveMagnetToTorrent } from "../../src/torrent/magnet-resolver.ts";
 import {
 	buildTorrentFileFromInfo,
 	MetadataPieceAssembler,
@@ -7,6 +9,7 @@ import {
 } from "../../src/torrent/metadata-cache.ts";
 import { extractInfoBytes } from "../../src/torrent/parser.ts";
 import { METADATA_BLOCK_SIZE } from "../../src/torrent/peer/extension.ts";
+import type { PeerInfo } from "../../src/torrent/types.ts";
 import { hex } from "../helpers/bytes.ts";
 import { singleFileTorrentFixture } from "../helpers/torrent-fixtures.ts";
 
@@ -75,4 +78,34 @@ describe("magnet metadata cache helpers", () => {
 		expect(assembler.complete).toBe(true);
 		expect(assembler.assemble()).toEqual(data);
 	});
+
+	test("uses DHT for trackerless magnet peer discovery", async () => {
+		const dht = new FakeMagnetDht([{ ip: "127.0.0.1", port: 1 }]);
+
+		await expect(
+			resolveMagnetToTorrent(
+				"magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567",
+				{ dht: dht as unknown as DhtClient },
+			),
+		).rejects.toThrow("Failed to fetch magnet metadata");
+
+		expect(dht.started).toBe(true);
+		expect(dht.lookups).toBe(1);
+	});
 });
+
+class FakeMagnetDht {
+	started = false;
+	lookups = 0;
+
+	constructor(private readonly peers: PeerInfo[]) {}
+
+	async start(): Promise<void> {
+		this.started = true;
+	}
+
+	async getPeers(): Promise<PeerInfo[]> {
+		this.lookups++;
+		return this.peers;
+	}
+}

--- a/tests/torrent/parser-metadata.test.ts
+++ b/tests/torrent/parser-metadata.test.ts
@@ -134,6 +134,16 @@ describe("TorrentMetadata", () => {
 		]);
 	});
 
+	test("parses private flag and DHT bootstrap nodes", () => {
+		const { metadata } = singleFileTorrentFixture({
+			private: true,
+			nodes: [["127.0.0.1", 6881]],
+		});
+
+		expect(metadata.private).toBe(true);
+		expect(metadata.nodes).toEqual([{ ip: "127.0.0.1", port: 6881 }]);
+	});
+
 	test("throws on invalid metadata", () => {
 		const fixture = singleFileTorrentFixture();
 		const decoded = decode(fixture.raw) as { [key: string]: BencodeValue };

--- a/tests/torrent/protocol.test.ts
+++ b/tests/torrent/protocol.test.ts
@@ -4,12 +4,14 @@ import {
 	decodeExtendedMessage,
 	decodeExtensionHandshake,
 	decodeUtMetadataMessage,
+	decodeUtPexMessage,
 	EXT_HANDSHAKE_ID,
 	encodeExtendedMessage,
 	encodeExtensionHandshake,
 	encodeUtMetadataData,
 	encodeUtMetadataReject,
 	encodeUtMetadataRequest,
+	encodeUtPexMessage,
 	LOCAL_UT_METADATA_ID,
 	supportsExtensionProtocol,
 } from "../../src/torrent/peer/extension.ts";
@@ -22,10 +24,12 @@ import {
 	decode,
 	decodeHave,
 	decodePiece,
+	decodePort,
 	decodeRequest,
 	encode,
 	encodeCancel,
 	encodeHave,
+	encodePort,
 	encodeRequest,
 	MSG,
 	msgName,
@@ -85,6 +89,7 @@ describe("extension protocol messages", () => {
 
 		expect(extended.extensionId).toBe(EXT_HANDSHAKE_ID);
 		expect(handshake.extensions.get("ut_metadata")).toBe(LOCAL_UT_METADATA_ID);
+		expect(handshake.extensions.get("ut_pex")).toBe(2);
 		expect(handshake.metadataSize).toBe(1234);
 	});
 
@@ -112,6 +117,15 @@ describe("extension protocol messages", () => {
 
 		expect(decodeExtendedMessage(wrapped).extensionId).toBe(4);
 	});
+
+	test("encodes and decodes ut_pex compact peer lists", () => {
+		const message = {
+			added: [{ ip: "127.0.0.1", port: 6881 }],
+			dropped: [{ ip: "10.0.0.2", port: 51413 }],
+		};
+
+		expect(decodeUtPexMessage(encodeUtPexMessage(message))).toEqual(message);
+	});
 });
 
 describe("peer protocol messages", () => {
@@ -128,6 +142,13 @@ describe("peer protocol messages", () => {
 			payload: undefined,
 		});
 		expect(msgName(MSG.INTERESTED)).toBe("INTERESTED");
+	});
+
+	test("encodes and decodes DHT PORT messages", () => {
+		const port = decode(encodePort(6881));
+
+		expect(port.type).toBe(MSG.PORT);
+		expect(decodePort(port.payload ?? new Uint8Array())).toBe(6881);
 	});
 
 	test("encodes and decodes have, request, cancel, and piece payloads", () => {


### PR DESCRIPTION
Summary:
- Add BEP 5 DHT peer discovery for torrents and trackerless magnets.
- Add BEP 11 PEX support through the extension protocol.
- Route tracker, DHT, and PEX peers through the shared discovery coordinator.