### PR TITLE
Add torrent categories and search

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,326 @@
+# Torrent Client — Implementation Plan
+
+> Stack: Bun + TypeScript + opentui.
+> Keep this file focused on active and future work. Completed phase bodies were removed to reduce AI-agent context cost.
+
+---
+
+## How to Use This Plan
+
+- **Start with the first non-complete phase** and update task status as work lands: `❌ Not started` → `🔄 In progress` → `✅ Done`.
+- **Use `REPORT.md` for prioritization**. The scored problem list and reasoning live there, not in this file.
+- **Avoid adding summary-table output** for future TUI phases unless the work is engine-only and can be verified with plain CLI args.
+
+---
+
+## Progress Overview
+
+| Phase | Title | Status | User-visible result |
+|---|---|---|---|
+| **0** | Foundation — parse, announce, get peers | ✅ Complete | CLI can read a `.torrent`, contact trackers, and print discovered peers |
+| **1** | Metadata & Storage | ✅ Complete | Client understands torrent contents and prepares/verifies files on disk |
+| **2** | Peer Connection & Handshake | ✅ Complete | Client can connect to real peers and show handshake/availability results |
+| **3** | Piece Download + Resume | ✅ Complete | CLI can download pieces, save progress, and resume after restart |
+| **4** | Multi-Peer, Seeding & Choking | ✅ Complete | Downloads can use multiple peers and upload verified pieces back to the swarm |
+| **5** | UDP Tracker | ✅ Complete | Torrents with UDP trackers can find peers instead of failing tracker discovery |
+| **6** | TUI Integration | ✅ Complete | TUI shows live torrent progress, speed, status, and add-torrent flow |
+| **7** | Multi-Torrent, Pause/Resume, Delete | ✅ Complete | Users can manage multiple torrents, pause/resume, delete, and restore sessions |
+| **8** | Detail Panel (Pieces / Peers / Files) | ✅ Complete | Users can inspect selected torrent pieces, peers, and files in the TUI |
+| **9** | Test Harness and Engine Fixtures | ✅ Complete | Users see fewer regressions; contributors can change engine code with confidence |
+| **10** | Recheck and Hashing Performance | ✅ Complete | Large torrents verify faster and the TUI stays responsive during checks |
+| **11** | Download Reliability | ✅ Complete | Downloads finish more consistently and peer lists stay fresh over time |
+| **12** | Extension Protocol and Magnet Metadata | ✅ Complete | Users can add magnet links, not only `.torrent` files |
+| **13** | Peer Discovery Expansion | ✅ Complete | More torrents find peers even when trackers are missing, stale, or incomplete |
+| **14** | Engine Controls | ✅ Complete | Users cap bandwidth; file picker dialog selects which files to download before start |
+| **15** | Additional Protocol Reliability | ✅ Complete | More edge-case torrents and network environments work correctly |
+| **16** | CLI and API Polish | ✅ Complete | CLI becomes easier to script, document, complete, and integrate |
+| **17** | TUI Search and Categories | ✅ Complete | Users can quickly find torrents and route new torrents into category paths |
+| **18** | TUI Sources and Tracker Controls | ❌ Not started | Users can diagnose peer sources and manage tracker health from the details panel |
+| **19** | Optional and Niche Features | ❌ Not started | Adds non-core workflows only if project direction expands |
+
+---
+
+## Completed Work Archive
+
+Phases 0-7 are complete and their detailed implementation plans were removed from this document to keep it small for AI agents. Use git history if the old task tables, console-output examples, or interface-contract notes are needed.
+
+Current completed capability baseline:
+
+| Area | Implemented capability |
+|---|---|
+| Torrent parsing | Bencode encode/decode, metadata parsing, info hash calculation, single-file and multi-file layout |
+| Trackers | HTTP trackers, BEP 12 announce-list, UDP trackers, compact peer parsing |
+| Peer protocol | Peer ID, handshake, message buffer, protocol encode/decode, bitfield/have/request/piece/cancel handling |
+| Download engine | Storage setup, piece verification, resume data, multi-peer download, rarest-first picker, pipelining |
+| Swarm behavior | Inbound listener, peer manager, choking/optimistic unchoke, seeding verified pieces |
+| TUI | Status bar, torrent table, add torrent dialog, toast/confirm dialogs, sidebar status filtering |
+| Multi-torrent | Concurrent torrents, pause/resume, delete with/without files, persisted session registry |
+
+Important retained implementation notes:
+
+- Do not call `process.exit()` from TUI code; use renderer cleanup.
+- `loadResume()` must not override `verifyAll()`; verification is the source of truth after files are deleted or changed.
+- OpenTUI shifted keys report as lowercase plus `key.shift: true`; do not rely on uppercase key names.
+- Normal piece completion must not send `cancel`; `cancel` belongs to endgame mode only.
+
+---
+
+## Phase 8: Detail Panel ✅ Complete
+
+### Goal
+
+Add a TUI-only detail panel for the selected torrent. Phase 8 does not add logging/debugging output; verification is based on visible TUI behavior and typecheck.
+
+**User-visible result:** Selecting a torrent now reveals a bottom details area where users can switch between piece progress, connected peers, and torrent file contents.
+
+### TUI Behavior
+
+| Feature | Behavior |
+|---|---|
+| Detail panel layout | Bottom split under the torrent table, same width as the torrent table, with its own border |
+| Tabs | `Pieces`, `Peers`, `Files` |
+| Tab navigation | `h` / `l` and `[` / `]` switch detail tabs while details is focused |
+| Focus navigation | `Tab` cycles sidebar → table → details |
+| CLI arg entry | `bun run start file.torrent` opens the TUI and adds/starts the torrent |
+
+### Tasks
+
+| # | Task | Status | Observable Output |
+|---|---|---|---|
+| 8.1 | Update store torrent detail shape for pieces, peers, and files | ✅ Done | `TorrentState` includes `pieceLength`, `peerDetails`, and `files` |
+| 8.2 | Add same-width bordered `DetailPanel` bottom split with Pieces tab | ✅ Done | TUI shows a bottom `DetailPanel` with `Pieces` tab and progress metadata |
+| 8.3 | Add Peers tab | ✅ Done | TUI shows peer count and peer rows when peer details are available |
+| 8.4 | Add Files tab | ✅ Done | TUI shows torrent payload file paths and sizes |
+| 8.5 | Wire details focus and `h` / `l` plus `[` / `]` detail tab navigation | ✅ Done | `Tab` focuses details; detail keys change the highlighted detail tab |
+| 8.6 | Add CLI arg TUI entry | ✅ Done | `bun run start test.torrent` opens the TUI and adds/starts the torrent |
+
+### Phase 8 Verification
+
+1. `bun run typecheck` passes.
+2. `bun run smoke` passes.
+3. `bun run start test.torrent` opens the TUI and shows the torrent list.
+4. Detail panel appears at the bottom of the content window with the same width as the torrent table and a separate border.
+5. `Pieces` tab shows selected torrent progress.
+6. `Tab` cycles sidebar → table → details, and `h` / `l` or `[` / `]` switches between `Pieces`, `Peers`, and `Files` while details is focused.
+7. `Peers` tab shows connected peer details when peers are available.
+8. `Files` tab shows torrent file paths and sizes.
+
+---
+
+## Long-Term Roadmap
+
+Future work should prioritize **performance >= reliability/protocol features > CLI quality > UI/UX**. See `REPORT.md` for scoring and reasoning.
+
+### Phase 9: Test Harness and Engine Fixtures
+
+**Goal:** Build a regression safety net before larger protocol and performance changes.
+
+**User-visible result:** Users should experience fewer broken releases and fewer regressions after future engine changes.
+
+| # | Task | Status | Verification |
+|---|---|---|---|
+| 9.1 | Add Bun test setup and fixture conventions | ✅ Done | `bun test` discovers torrent engine tests |
+| 9.2 | Add parser and metadata fixtures | ✅ Done | Bencode round trips, `info_hash`, single-file, and multi-file cases pass |
+| 9.3 | Add peer protocol/message-buffer fixtures | ✅ Done | Partial TCP frames and message encode/decode cases pass |
+| 9.4 | Add tracker response fixtures | ✅ Done | HTTP/UDP compact peer parsing and tracker errors are covered |
+| 9.5 | Add storage, resume, and downloader state tests | ✅ Done | Piece verification, stale resume, pause/resume, and completion cases pass |
+
+### Phase 10: Recheck and Hashing Performance
+
+**Goal:** Improve large-torrent verification throughput while keeping the TUI responsive.
+
+**User-visible result:** Opening or resuming large torrents should spend less time checking files, and the TUI should not feel frozen while checking.
+
+| # | Task | Status | Verification |
+|---|---|---|---|
+| 10.1 | Benchmark current verification behavior on representative fixture sizes | ✅ Done | CLI benchmark output records pieces/sec and max event-loop delay |
+| 10.2 | Improve verification scheduling and cancellation | ✅ Done | TUI remains responsive while checking; stopped torrents cancel cleanly |
+| 10.3 | Add worker-backed or parallel hashing path if benchmarks justify it | ✅ Done | Benchmarks stayed below the worker threshold without corrupting storage state |
+| 10.4 | Add regression coverage for verification progress and resume consistency | ✅ Done | `bun test` covers valid, missing, and corrupt piece states |
+
+### Phase 11: Download Reliability ✅ Complete
+
+**Goal:** Fix completion stalls and tracker lifecycle gaps before adding larger peer-discovery systems.
+
+**User-visible result:** Downloads should be less likely to stall near the end, and long-running torrents should keep finding peers without restarting the app.
+
+| # | Task | Status | Verification |
+|---|---|---|---|
+| 11.1 | Add endgame mode for the final outstanding blocks | ✅ Done | Last pieces can be requested from multiple peers and duplicate responses are ignored safely |
+| 11.2 | Send `cancel` only for redundant endgame requests | ✅ Done | Protocol tests confirm normal piece completion does not send cancel |
+| 11.3 | Re-announce to trackers at their returned intervals | ✅ Done | Peer refresh happens without restarting the torrent |
+| 11.4 | Send tracker `started`, `completed`, and `stopped` events | ✅ Done | CLI download emits correct tracker lifecycle requests |
+| 11.5 | Add tracker retry/backoff and peer merge behavior | ✅ Done | Failed trackers do not block healthy trackers or existing peers |
+
+### Phase 12: Extension Protocol and Magnet Metadata ✅ Complete
+
+**Goal:** Complete BEP 10 support and use it to add BEP 9 magnet metadata downloads.
+
+**User-visible result:** Users can paste or open magnet links directly; the client fetches metadata from peers and starts the torrent without a `.torrent` file.
+
+| # | Task | Status | Verification |
+|---|---|---|---|
+| 12.1 | Parse and advertise BEP 10 extension handshakes | ✅ Done | `extension.ts` builds reserved bytes and encodes/decodes extension handshakes; `PeerConnection` sends the handshake on connect when `extensionCapable` |
+| 12.2 | Add extension message routing in `PeerConnection` | ✅ Done | `onExtendedMessage` routes to extension handshake or `ut_metadata` handler; unknown extensions are logged and ignored safely |
+| 12.3 | Parse magnet URIs in CLI and TUI add flows | ✅ Done | `parseMagnetUri` handles hex/base32 btih, trackers, x.pe peers, display name; `app.ts` and `index.ts` both route magnet inputs to `bridge.addMagnet`; add-torrent dialog accepts magnet input |
+| 12.4 | Implement BEP 9 `ut_metadata` request/response flow | ✅ Done | `magnet-resolver.ts` discovers peers, fetches all metadata pieces via extension protocol, assembles and verifies by info hash, builds a `.torrent` file in memory |
+| 12.5 | Persist fetched metadata for future starts | ✅ Done | Fetched metadata is written to `~/.local/share/torrent-tui/metadata/<hash>.torrent`; resolver checks cache before connecting to peers |
+
+### Phase 13: Peer Discovery Expansion ✅ Complete
+
+**Goal:** Reduce dependence on trackers by adding DHT first, then PEX.
+
+**User-visible result:** Torrents with dead, weak, or missing trackers should still find peers through DHT and peer exchange.
+
+| # | Task | Status | Verification |
+|---|---|---|---|
+| 13.1 | Implement BEP 5 DHT node ID, routing table, and bootstrap | ✅ Done | DHT node IDs persist, bootstrap nodes seed a bounded routing table, and torrent `nodes` are parsed |
+| 13.2 | Implement DHT `get_peers` / `announce_peer` flow | ✅ Done | Trackerless magnets and torrents can discover peers from DHT; complete torrents announce back to DHT |
+| 13.3 | Merge DHT peers into the existing peer manager | ✅ Done | Tracker, DHT, and PEX peers flow through one `PeerManager.connect()` path with duplicate and banned-peer filtering |
+| 13.4 | Implement BEP 11 PEX over the extension protocol | ✅ Done | Peers advertise `ut_pex`, decode incoming PEX peers, and send added/dropped peer batches |
+
+### Phase 14: Engine Controls ✅ Complete
+
+**Goal:** Add controls that make downloads predictable and manageable for real users.
+
+**User-visible result:** Users can cap download/upload speeds and skip unwanted files in multi-file torrents.
+
+| # | Task | Status | Verification |
+|---|---|---|---|
+| 14.1 | Add download/upload speed limits | ✅ Done | `downloadRateLimitBps` / `uploadRateLimitBps` in settings.json; token-bucket enforced in Downloader |
+| 14.2 | Improve bandwidth accounting across peers and torrents | ✅ Done | Speed reported via 1s setInterval; per-file ━━━ progress bars in Files tab |
+| 14.3 | Add file selection picker | ✅ Done | `FilePickerDialog` opens after add for multi-file torrents; `skippedFileIndices` drives piece picker; persisted to resume |
+| 14.4 | Single-file torrents skip picker | ✅ Done | Picker only appears when torrent has >1 file; single-file starts immediately |
+
+### Phase 15: Additional Protocol Reliability
+
+**Goal:** Fill mature-client protocol gaps after core discovery, completion, and controls are stable.
+
+**User-visible result:** More torrents work in real-world conditions, including torrents with web seeds, padding files, LAN peers, or peers requiring encryption.
+
+| # | Task | Status | Verification |
+|---|---|---|---|
+| 15.1 | Add BEP 19 WebSeed support | ✅ Done | Torrents with HTTP seeds can download and verify pieces from web seeds |
+| 15.2 | Add blocklist loading and peer filtering | ✅ Done | Blocked peers are not connected or accepted inbound |
+| 15.3 | Add protocol encryption / MSE-PE | ✅ Done | Encrypted-capable peers can connect without breaking plaintext peers |
+| 15.4 | Add BEP 47 padding file handling | ✅ Done | Padding files are not exposed as normal user payload files |
+| 15.5 | Add LSD peer discovery | ✅ Done | LAN peers can be discovered without trackers |
+
+### Phase 16: CLI and API Polish ✅ Complete
+
+**Goal:** Improve power-user workflows once the engine behavior is reliable.
+
+**User-visible result:** Users can inspect torrents from the CLI and read man-page help.
+
+| # | Task | Status | Verification |
+|---|---|---|---|
+| 16.1 | Add `torrent-tui <file.torrent> --info` | ✅ Done | CLI prints torrent metadata without starting the TUI |
+| 16.2 | Add shell completions | ⏭️ Dropped | Dropped after review because Bun global installs cannot activate them reliably or automatically |
+| 16.3 | Add a man page | ✅ Done | Packaged install includes local CLI documentation |
+| 16.4 | Add stable programmatic engine exports | ⏭️ Dropped | Dropped after scope review; keep package focused on the CLI/TUI for now |
+| 16.5 | Add scripting hooks | ⏭️ Deferred | Deferred by product decision; automation hooks can be planned later |
+
+### Phase 17: TUI Search and Categories ✅ Complete
+
+**Goal:** Add the low-risk TUI organization workflow from mature clients before deeper source diagnostics.
+
+**User-visible result:** Users can search the torrent list by name, manage category save-path presets, and choose a category/save directory while adding a torrent.
+
+#### Product Direction
+
+qBittorrent's category model is the best fit for this project because it maps a simple user choice to a concrete save path. Transmission labels and Deluge add options point in the same direction: users expect to choose where a torrent lands during add, without editing global config for every torrent.
+
+- qBittorrent-style categories as save-path presets during add, implemented with a small local config shape rather than automatic torrent management.
+- A name-only quick search for the table; sorting and advanced filtering stay out of this phase.
+- Category sidebar filters were dropped after implementation review. Categories now route save paths and can be managed, but the sidebar remains status-only.
+- Tags stay secondary. Add them only as non-routing labels if they fit cleanly after category paths are working.
+
+#### Architecture Notes
+
+- Treat **category** as the path-driving preset: one torrent has at most one category, and each category may define a default save path.
+- Treat **tags** as non-routing labels. Do not add tag-driven paths in this phase; add tags only if they can be represented cleanly as metadata labels without changing storage behavior.
+- Per-torrent save paths require `TorrentBridge` / `TorrentEntry` to stop assuming the global `downloadPath` for every active torrent.
+- Existing sessions without category/save-path metadata must continue to restore using the current global download path behavior.
+
+| # | Task | Status | Verification |
+|---|---|---|---|
+| 17.1 | Add category settings with default save paths | ✅ Done | Settings persist categories with name and save path; invalid defaults are normalized |
+| 17.2 | Add per-torrent category and save-path state | ✅ Done | `TorrentState` and the session registry preserve category, category name, frozen save path, and target path without breaking existing sessions |
+| 17.3 | Add category/save-path selection to the add flow | ✅ Done | After choosing a `.torrent` or resolving magnet metadata, users choose category/save path before file selection/start; the chosen path is used for storage and resume |
+| 17.4 | Add sidebar category section | ⏭️ Dropped | Category/uncategorized sidebar filters were removed; the sidebar now stays status-only while categories remain save-path presets |
+| 17.5 | Add name-only quick search for the torrent table | ✅ Done | `/` opens search mode; torrent rows narrow by name only; clearing search restores the current status view |
+| 17.6 | Persist category/save-path restore behavior | ✅ Done | Restored torrents keep their category, save path, selected files, and progress after app restart |
+| 17.7 | Add category management and path-picking dialogs | ✅ Done | Users can create/edit/delete category presets, browse paths within the home directory, and see long paths trimmed with `~` home abbreviation |
+
+#### Phase 17 Verification
+
+1. `bun test` passes, including focused tests for category settings, per-torrent save paths, restore behavior, category dialogs, directory picking, sidebar rows, and name search filtering.
+2. `npx tsc --noEmit` passes.
+3. `bun run check:fix` passes.
+4. TUI add flow can choose a category path, select files if needed, and start the torrent from that path.
+5. Restarting the app restores category, save path, and file selection without corrupting existing sessions.
+
+### Phase 18: TUI Sources and Tracker Controls
+
+**Goal:** Surface the engine's discovery behavior so users can diagnose stalled torrents without logs.
+
+**User-visible result:** Users can inspect trackers, DHT, PEX, LSD, and web seeds in a `Sources` tab and refresh tracker discovery from the TUI.
+
+#### Product Direction
+
+qBittorrent, Transmission, Deluge, and rTorrent all expose more than aggregate speed/progress once a user selects a torrent. This phase keeps that power scoped to diagnostics and tracker controls:
+
+- qBittorrent-style tracker/source visibility and controls, rendered as a compact TUI `Sources` tab.
+- Transmission-style peer-source and tracker runtime fields, kept in app state instead of requiring an external RPC layer.
+- Runtime diagnostics first; persist only user-owned tracker overrides.
+
+#### Architecture Notes
+
+- Do not mutate original `.torrent` files when users add/edit trackers.
+- Keep source diagnostics runtime-first. Persist tracker overrides only if add/remove tracker actions land.
+- Tracker/source state should flow from `TrackerCoordinator` / `DiscoveryCoordinator` into `TorrentBridge`, then into `TorrentState`.
+- If tracker editing risks delaying the phase, ship read-only diagnostics plus manual refresh first and leave edit actions as a follow-up task.
+
+| # | Task | Status | Verification |
+|---|---|---|---|
+| 18.1 | Add source diagnostics state for trackers, DHT, PEX, LSD, and web seeds | ❌ Not started | Store state can show tracker URL/status/error/seed/leech counts, source peer counts, web seed availability, and last/next announce data for the selected torrent |
+| 18.2 | Add a `Sources` detail tab | ❌ Not started | Detail panel includes `Sources`; users can inspect tracker/source health for the selected torrent |
+| 18.3 | Add manual source refresh/reannounce | ❌ Not started | Users can trigger tracker refresh/reannounce from the TUI and see source state update |
+| 18.4 | Add tracker edit actions if the data model is ready | ❌ Not started | Users can add/remove tracker URLs without modifying the original `.torrent`; overrides persist across restart |
+| 18.5 | Add source-state regression coverage | ❌ Not started | Tests cover tracker success/failure state, DHT/PEX/LSD peer source counts, and refresh actions |
+
+#### Phase 18 Verification
+
+1. `bun test` passes, including focused tests for source-state mapping and manual refresh actions.
+2. `npx tsc --noEmit` passes.
+3. `Sources` tab shows tracker/source diagnostics for a real torrent.
+4. Manual refresh/reannounce updates source state without restarting the torrent.
+5. Tracker overrides, if implemented, survive restart without modifying original `.torrent` files.
+
+### Phase 19: Optional and Niche Features
+
+**Goal:** Only pursue these if project goals expand beyond the current download-first Bun TUI.
+
+**User-visible result:** Adds secondary workflows such as sequential downloading, torrent creation, custom themes, or broader runtime/peer-transport compatibility.
+
+| # | Task | Status | Verification |
+|---|---|---|---|
+| 19.1 | Add sequential download mode | ❌ Not started | Piece picker can switch between rarest-first and sequential modes |
+| 19.2 | Add torrent creation | ❌ Not started | CLI can create valid single-file and multi-file `.torrent` files |
+| 19.3 | Add color customization | ❌ Not started | User theme settings load from config |
+| 19.4 | Reconsider Node.js compatibility | ❌ Not started | Decision record explains runtime tradeoffs before code changes |
+| 19.5 | Reconsider WebRTC support | ❌ Not started | Decision record explains whether WebTorrent compatibility is a goal |
+
+---
+
+## Reference: BitTorrent Protocol Facts
+
+- **Block size**: 2^14 = 16,384 bytes. Close connections requesting more.
+- **Pipelining**: Keep several piece requests queued at once; libtorrent default is 10-20.
+- **Keepalive**: Send every 2 minutes. Timeout dead connections quickly when data is expected.
+- **Choking**: Recalculate every 10 seconds. Unchoke top 4 by download rate, or upload rate when seeding. Use 1 optimistic unchoke rotating every 30 seconds.
+- **Cancel messages**: Only send during endgame mode. Do not send cancel on normal piece completion.
+- **Bitfield**: Sent as first message after handshake. Skip if client has no pieces yet.
+- **Peer count**: Above roughly 25 peers, new peers are unlikely to increase download speed much. Default 50 is fine; effective ceiling is about 30-40 active peers.
+- **Port**: Try 6881 first, then 6882-6889.
+- **Inbound connections**: Required for full swarm participation. Without it, peers discovered via tracker cannot connect back to you.

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,25 +3,53 @@ import {
 	createCliRenderer,
 	type PasteEvent,
 } from "@opentui/core";
-import { loadConfig } from "./config";
+import { loadConfig, saveConfig } from "./config";
+import { createCategory, updateCategory } from "./config/categories";
+import type { AppSettings } from "./config/settings";
 import { AppController } from "./controllers/app-controller";
 import { AddTorrentDialog } from "./layout/add-torrent-dialog";
+import {
+	CategoryDialog,
+	type CategoryDialogResult,
+} from "./layout/category-dialog";
+import { CategoryManagerDialog } from "./layout/category-manager-dialog";
+import {
+	CategorySelectDialog,
+	type CategorySelectOption,
+} from "./layout/category-select-dialog";
 import { ConfirmDialog } from "./layout/confirm-dialog";
 import { ContentWindow } from "./layout/content-window";
+import { DirectoryPickerDialog } from "./layout/directory-picker-dialog";
 import { FilePickerDialog } from "./layout/file-picker-dialog";
 import { Sidebar } from "./layout/sidebar";
 import { StatusBar } from "./layout/status-bar";
 import { ToastManager } from "./layout/toast-manager";
 import { Store } from "./store";
-import { TorrentBridge } from "./torrent/bridge";
-import { isMagnetUri } from "./torrent/magnet";
+import { type PreparedTorrentAdd, TorrentBridge } from "./torrent/bridge";
 import type { LayoutDimensions } from "./types/layout";
 import { env } from "./utils/env";
 import { calculateLayout } from "./utils/layout";
+import { resolvePath } from "./utils/paths";
+
+type ModalId =
+	| "add-source"
+	| "category-select"
+	| "new-category"
+	| "category-manager"
+	| "directory-picker"
+	| "file-picker";
+
+type CategoryFlow = { kind: "add" } | { kind: "reassign"; torrentId: string };
+type CategoryDialogContext =
+	| { kind: "select-new" }
+	| { kind: "manager-new" }
+	| { kind: "manager-edit"; categoryId: string };
 
 const INITIAL_STATE = {
 	selectedIndex: 0,
 	selectedView: "All",
+	searchQuery: "",
+	categories: [],
 	torrents: [],
 	totalDownloadBps: 0,
 	totalUploadBps: 0,
@@ -39,20 +67,32 @@ export class App {
 	private addDialog!: AddTorrentDialog;
 	private confirmDialog!: ConfirmDialog;
 	private filePickerDialog!: FilePickerDialog;
+	private directoryPickerDialog!: DirectoryPickerDialog;
+	private categoryDialog!: CategoryDialog;
+	private categoryManagerDialog!: CategoryManagerDialog;
+	private categorySelectDialog!: CategorySelectDialog;
 	private layout!: LayoutDimensions;
 	private resizeTimeout: ReturnType<typeof setTimeout> | null = null;
+	private config!: AppSettings;
+	private pendingAdd: PreparedTorrentAdd | null = null;
+	private modalStack: ModalId[] = [];
+	private categoryFlow: CategoryFlow | null = null;
+	private categoryDialogContext: CategoryDialogContext | null = null;
 
 	async start(initialTorrentPath?: string): Promise<void> {
-		const config = loadConfig();
+		this.config = loadConfig();
 
 		this.renderer = await createCliRenderer({
 			exitOnCtrlC: true,
 			openConsoleOnError: env.SHOW_CONSOLE,
 			useConsole: env.SHOW_CONSOLE,
 		});
-		this.store = new Store(INITIAL_STATE);
+		this.store = new Store({
+			...INITIAL_STATE,
+			categories: this.config.categories,
+		});
 		this.layout = calculateLayout(this.renderer.width, this.renderer.height);
-		this.bridge = new TorrentBridge(this.store, config);
+		this.bridge = new TorrentBridge(this.store, this.config);
 
 		this.sidebar = new Sidebar(this.renderer, this.store, this.layout);
 		this.contentWindow = new ContentWindow(
@@ -65,10 +105,23 @@ export class App {
 		this.addDialog = new AddTorrentDialog(
 			this.renderer,
 			this.layout,
-			config.torrentFolder,
+			this.config.torrentFolder,
 		);
 		this.confirmDialog = new ConfirmDialog(this.renderer, this.layout);
 		this.filePickerDialog = new FilePickerDialog(this.renderer, this.layout);
+		this.directoryPickerDialog = new DirectoryPickerDialog(
+			this.renderer,
+			this.layout,
+		);
+		this.categoryDialog = new CategoryDialog(this.renderer, this.layout);
+		this.categoryManagerDialog = new CategoryManagerDialog(
+			this.renderer,
+			this.layout,
+		);
+		this.categorySelectDialog = new CategorySelectDialog(
+			this.renderer,
+			this.layout,
+		);
 
 		this.controller = new AppController(
 			this.renderer,
@@ -83,34 +136,39 @@ export class App {
 
 		// Wire controller callbacks
 		this.controller.onAddTorrent = () => {
+			this.modalStack = ["add-source"];
 			this.addDialog.open();
+			this.syncDialogFocusMode();
 		};
 
 		this.controller.onDialogClose = () => {
-			if (this.filePickerDialog.getIsOpen()) {
-				this.filePickerDialog.confirmWithAllFiles();
-			} else {
-				this.addDialog.close();
-			}
+			this.closeTopModal();
 		};
 
 		this.controller.onDialogInput = (key) => {
-			if (this.filePickerDialog.getIsOpen())
-				return this.filePickerDialog.handleInput(key);
-			return this.addDialog.handleInput(key);
+			switch (this.currentModal()) {
+				case "add-source":
+					return this.addDialog.handleInput(key);
+				case "category-select":
+					return this.categorySelectDialog.handleInput(key);
+				case "new-category":
+					return this.categoryDialog.handleInput(key);
+				case "category-manager":
+					return this.categoryManagerDialog.handleInput(key);
+				case "directory-picker":
+					return this.directoryPickerDialog.handleInput(key);
+				case "file-picker":
+					return this.filePickerDialog.handleInput(key);
+				default:
+					return false;
+			}
 		};
 
 		this.filePickerDialog.onConfirm = (id, selectedIndices) => {
-			this.controller.focusMode = "global";
+			this.removeModal("file-picker");
+			this.syncDialogFocusMode();
 			this.bridge.setFileSelection(id, selectedIndices);
-			this.bridge.startTorrent(id).catch((err: unknown) => {
-				this.toastManager.show({
-					id: `start-err-${Date.now()}`,
-					type: "error",
-					title: "Failed to start",
-					message: err instanceof Error ? err.message : String(err),
-				});
-			});
+			this.startTorrentWithToast(id);
 		};
 
 		this.controller.onDialogPaste = (event: PasteEvent) => {
@@ -137,15 +195,103 @@ export class App {
 		this.controller.onRemoveTorrent = (id, deleteFiles) => {
 			this.bridge.removeTorrent(id, deleteFiles);
 		};
+		this.controller.onSetTorrentCategory = (id) => {
+			const torrent = this.store.getState().torrents.find((t) => t.id === id);
+			if (!torrent) return;
+			this.openCategorySelectForReassign(id);
+		};
+		this.controller.onManageCategories = () => {
+			this.openCategoryManager();
+		};
 
 		this.addDialog.onSelect = (filePath) => {
-			this.controller.focusMode = "global";
+			this.removeModal("add-source");
+			this.syncDialogFocusMode();
 			const filename = filePath.split("/").pop() ?? filePath;
 			this.renderer.requestRender();
 
 			setTimeout(() => {
 				this.addTorrentInBackground(filePath, filename);
 			}, 0);
+		};
+
+		this.directoryPickerDialog.onSelect = (path) => {
+			this.removeModal("directory-picker");
+			this.categoryDialog.setSavePath(path);
+			this.categoryDialog.show();
+			this.syncDialogFocusMode();
+		};
+		this.directoryPickerDialog.onCancel = () => {
+			this.removeModal("directory-picker");
+			this.categoryDialog.show();
+			this.syncDialogFocusMode();
+		};
+		this.categoryDialog.onBrowse = (initialPath) => {
+			this.openDirectoryPickerForNewCategory(initialPath);
+		};
+		this.categoryDialog.onConfirm = (result) => this.createCategory(result);
+		this.categoryDialog.onCancel = () => {
+			this.removeModal("new-category");
+			if (this.categoryDialogContext?.kind === "select-new") {
+				this.categorySelectDialog.show();
+			} else {
+				this.categoryManagerDialog.show(this.config.categories);
+			}
+			this.categoryDialogContext = null;
+			this.syncDialogFocusMode();
+		};
+		this.categorySelectDialog.onSelect = (category) =>
+			this.applySelectedCategory(category);
+		this.categorySelectDialog.onNewCategory = () => {
+			this.categorySelectDialog.hide();
+			this.modalStack.push("new-category");
+			this.categoryDialogContext = { kind: "select-new" };
+			this.categoryDialog.open(this.config.downloadPath);
+			this.syncDialogFocusMode();
+		};
+		this.categorySelectDialog.onCancel = () => {
+			this.cancelCategoryFlow();
+		};
+		this.categoryManagerDialog.onCancel = () => {
+			this.removeModal("category-manager");
+			this.syncDialogFocusMode();
+		};
+		this.categoryManagerDialog.onNew = () => {
+			this.categoryManagerDialog.hide();
+			this.modalStack.push("new-category");
+			this.categoryDialogContext = { kind: "manager-new" };
+			this.categoryDialog.open(this.config.downloadPath);
+			this.syncDialogFocusMode();
+		};
+		this.categoryManagerDialog.onEdit = (category) => {
+			this.categoryManagerDialog.hide();
+			this.modalStack.push("new-category");
+			this.categoryDialogContext = {
+				kind: "manager-edit",
+				categoryId: category.id,
+			};
+			this.categoryDialog.open(category.savePath ?? this.config.downloadPath, {
+				name: category.name,
+				savePath: category.savePath,
+				title: "Edit category",
+			});
+			this.syncDialogFocusMode();
+		};
+		this.categoryManagerDialog.onDelete = (category) => {
+			this.categoryManagerDialog.hide();
+			this.controller.confirm(
+				`Delete category ${category.name}?`,
+				"Torrents stay in place and become uncategorized.",
+				() => {
+					this.deleteCategory(category.id);
+					this.categoryManagerDialog.show(this.config.categories);
+					this.syncDialogFocusMode();
+				},
+				() => {
+					this.categoryManagerDialog.show(this.config.categories);
+					this.syncDialogFocusMode();
+				},
+			);
 		};
 
 		await this.bridge.restoreSession();
@@ -176,6 +322,10 @@ export class App {
 			this.addDialog.updateLayout(this.layout);
 			this.confirmDialog.updateLayout(this.layout);
 			this.filePickerDialog.updateLayout(this.layout);
+			this.directoryPickerDialog.updateLayout(this.layout);
+			this.categoryDialog.updateLayout(this.layout);
+			this.categoryManagerDialog.updateLayout(this.layout);
+			this.categorySelectDialog.updateLayout(this.layout);
 		}, 100);
 	}
 
@@ -184,9 +334,7 @@ export class App {
 		filename: string,
 	): Promise<void> {
 		try {
-			const result = isMagnetUri(input)
-				? await this.bridge.addMagnet(input)
-				: await this.bridge.addTorrent(input);
+			const result = await this.bridge.prepareAdd(input);
 			this.toastManager.show({
 				id: `added-${Date.now()}`,
 				type: result.added ? "success" : "info",
@@ -196,22 +344,8 @@ export class App {
 			this.renderer.requestRender();
 
 			if (result.added) {
-				const torrent = this.store
-					.getState()
-					.torrents.find((t) => t.id === result.id);
-				if (torrent && torrent.files.length > 1) {
-					this.controller.focusMode = "dialog";
-					this.filePickerDialog.open(result.id, torrent.files, torrent.name);
-				} else {
-					this.bridge.startTorrent(result.id).catch((err: unknown) => {
-						this.toastManager.show({
-							id: `start-err-${Date.now()}`,
-							type: "error",
-							title: "Failed to start",
-							message: err instanceof Error ? err.message : String(err),
-						});
-					});
-				}
+				this.pendingAdd = result;
+				this.openCategorySelectForAdd();
 			}
 		} catch (err) {
 			this.toastManager.show({
@@ -221,5 +355,277 @@ export class App {
 				message: err instanceof Error ? err.message : String(err),
 			});
 		}
+	}
+
+	private confirmPendingAdd(selection: {
+		categoryId: string | null;
+		categoryName: string | null;
+		savePath: string;
+	}): void {
+		const pending = this.pendingAdd;
+		if (!pending) return;
+		this.pendingAdd = null;
+		this.bridge
+			.confirmAdd(pending, {
+				categoryId: selection.categoryId,
+				categoryName: selection.categoryName,
+				savePath: selection.savePath,
+			})
+			.then((result) => {
+				if (!result.added) {
+					this.clearCategoryFlow();
+					return;
+				}
+				const torrent = this.store
+					.getState()
+					.torrents.find((t) => t.id === result.id);
+				if (torrent && torrent.files.length > 1) {
+					this.clearCategoryFlow({ keepFocus: true });
+					this.modalStack = ["file-picker"];
+					this.filePickerDialog.open(result.id, torrent.files, torrent.name);
+					this.syncDialogFocusMode();
+				} else {
+					this.clearCategoryFlow();
+					this.startTorrentWithToast(result.id);
+				}
+			})
+			.catch((err: unknown) => {
+				this.clearCategoryFlow();
+				this.toastManager.show({
+					id: `confirm-add-err-${Date.now()}`,
+					type: "error",
+					title: "Failed to add",
+					message: err instanceof Error ? err.message : String(err),
+				});
+			});
+	}
+
+	private createCategory(result: CategoryDialogResult): void {
+		if (this.categoryDialogContext?.kind === "manager-edit") {
+			this.updateExistingCategory(
+				this.categoryDialogContext.categoryId,
+				result,
+			);
+			this.removeModal("new-category");
+			this.categoryDialogContext = null;
+			this.categoryManagerDialog.show(this.config.categories);
+			this.syncDialogFocusMode();
+			return;
+		}
+
+		const category = createCategory(this.config.categories, {
+			name: result.name,
+			savePath: result.savePath,
+		});
+		this.config = {
+			...this.config,
+			categories: [...this.config.categories, category],
+		};
+		saveConfig(this.config);
+		this.store.setState({ categories: this.config.categories });
+		this.removeModal("new-category");
+		if (this.categoryDialogContext?.kind === "manager-new") {
+			this.categoryDialogContext = null;
+			this.categoryManagerDialog.show(this.config.categories);
+			this.syncDialogFocusMode();
+			return;
+		}
+		this.categoryDialogContext = null;
+		this.categorySelectDialog.close();
+		this.removeModal("category-select");
+		this.applySelectedCategory(category);
+	}
+
+	private updateExistingCategory(
+		categoryId: string,
+		result: CategoryDialogResult,
+	): void {
+		const before = this.config.categories.find(
+			(category) => category.id === categoryId,
+		);
+		this.config = {
+			...this.config,
+			categories: updateCategory(this.config.categories, categoryId, {
+				name: result.name,
+				savePath: result.savePath,
+			}),
+		};
+		saveConfig(this.config);
+		this.store.setState({ categories: this.config.categories });
+		const after = this.config.categories.find(
+			(category) => category.id === categoryId,
+		);
+		if (before && after && before.name !== after.name) {
+			this.bridge.renameCategory(categoryId, after.name);
+		}
+	}
+
+	private deleteCategory(categoryId: string): void {
+		this.config = {
+			...this.config,
+			categories: this.config.categories.filter(
+				(category) => category.id !== categoryId,
+			),
+			defaultCategoryId:
+				this.config.defaultCategoryId === categoryId
+					? null
+					: this.config.defaultCategoryId,
+		};
+		saveConfig(this.config);
+		this.store.setState({
+			categories: this.config.categories,
+		});
+		this.bridge.clearCategory(categoryId);
+	}
+
+	private openCategoryManager(): void {
+		this.modalStack = ["category-manager"];
+		this.categoryManagerDialog.open(this.config.categories);
+		this.syncDialogFocusMode();
+	}
+
+	private openCategorySelectForAdd(): void {
+		this.categoryFlow = { kind: "add" };
+		this.modalStack = ["category-select"];
+		this.categorySelectDialog.open({
+			categories: this.store.getState().categories,
+			defaultCategoryId: this.config.defaultCategoryId,
+			globalDownloadPath: resolvePath(this.config.downloadPath),
+			mode: "add",
+		});
+		this.syncDialogFocusMode();
+	}
+
+	private openCategorySelectForReassign(torrentId: string): void {
+		const torrent = this.store
+			.getState()
+			.torrents.find((t) => t.id === torrentId);
+		if (!torrent) return;
+		this.categoryFlow = { kind: "reassign", torrentId };
+		this.modalStack = ["category-select"];
+		this.categorySelectDialog.open({
+			categories: this.store.getState().categories,
+			currentCategoryId: torrent.categoryId,
+			mode: "reassign",
+		});
+		this.syncDialogFocusMode();
+	}
+
+	private openDirectoryPickerForNewCategory(initialPath: string): void {
+		this.categoryDialog.hide();
+		this.modalStack.push("directory-picker");
+		this.directoryPickerDialog.open(initialPath, "Choose category path");
+		this.syncDialogFocusMode();
+	}
+
+	private applySelectedCategory(category: CategorySelectOption | null): void {
+		const flow = this.categoryFlow;
+		if (!flow) {
+			this.syncDialogFocusMode();
+			return;
+		}
+
+		if (flow.kind === "reassign") {
+			this.bridge.setTorrentCategory(
+				flow.torrentId,
+				category ? { id: category.id ?? "", name: category.name } : null,
+			);
+			this.clearCategoryFlow();
+			return;
+		}
+
+		const savePath = resolvePath(
+			category?.savePath ?? this.config.downloadPath,
+		);
+		this.confirmPendingAdd({
+			categoryId: category?.id ?? null,
+			categoryName: category?.name ?? null,
+			savePath,
+		});
+	}
+
+	private closeTopModal(): void {
+		switch (this.currentModal()) {
+			case "add-source":
+				this.addDialog.close();
+				this.removeModal("add-source");
+				this.syncDialogFocusMode();
+				return;
+			case "category-select":
+				this.cancelCategoryFlow();
+				return;
+			case "new-category":
+				this.categoryDialog.close();
+				this.removeModal("new-category");
+				if (this.categoryDialogContext?.kind === "select-new") {
+					this.categorySelectDialog.show();
+				} else {
+					this.categoryManagerDialog.show(this.config.categories);
+				}
+				this.categoryDialogContext = null;
+				this.syncDialogFocusMode();
+				return;
+			case "category-manager":
+				this.categoryManagerDialog.close();
+				this.removeModal("category-manager");
+				this.syncDialogFocusMode();
+				return;
+			case "directory-picker":
+				this.directoryPickerDialog.close();
+				this.removeModal("directory-picker");
+				this.categoryDialog.show();
+				this.syncDialogFocusMode();
+				return;
+			case "file-picker":
+				this.filePickerDialog.confirmWithAllFiles();
+				return;
+			default:
+				this.syncDialogFocusMode();
+		}
+	}
+
+	private cancelCategoryFlow(): void {
+		this.pendingAdd = null;
+		this.clearCategoryFlow();
+	}
+
+	private clearCategoryFlow(options: { keepFocus?: boolean } = {}): void {
+		this.categoryFlow = null;
+		this.categoryDialogContext = null;
+		this.categorySelectDialog.close();
+		this.categoryDialog.close();
+		this.directoryPickerDialog.close();
+		this.modalStack = this.modalStack.filter(
+			(modal) =>
+				modal !== "category-select" &&
+				modal !== "new-category" &&
+				modal !== "directory-picker",
+		);
+		if (!options.keepFocus) this.syncDialogFocusMode();
+	}
+
+	private currentModal(): ModalId | null {
+		return this.modalStack[this.modalStack.length - 1] ?? null;
+	}
+
+	private removeModal(modal: ModalId): void {
+		const index = this.modalStack.lastIndexOf(modal);
+		if (index >= 0) this.modalStack.splice(index, 1);
+	}
+
+	private syncDialogFocusMode(): void {
+		this.controller.focusMode =
+			this.modalStack.length > 0 ? "dialog" : "global";
+	}
+
+	private startTorrentWithToast(id: string): void {
+		this.bridge.startTorrent(id).catch((err: unknown) => {
+			this.toastManager.show({
+				id: `start-err-${Date.now()}`,
+				type: "error",
+				title: "Failed to start",
+				message: err instanceof Error ? err.message : String(err),
+			});
+		});
 	}
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -177,6 +177,8 @@ export class App {
 
 		this.controller.onQuit = async () => {
 			await this.bridge.stopAll();
+			this.controller.stop();
+			this.toastManager.destroy();
 			this.renderer.destroy();
 		};
 
@@ -331,21 +333,15 @@ export class App {
 
 	private async addTorrentInBackground(
 		input: string,
-		filename: string,
+		_filename: string,
 	): Promise<void> {
 		try {
 			const result = await this.bridge.prepareAdd(input);
-			this.toastManager.show({
-				id: `added-${Date.now()}`,
-				type: result.added ? "success" : "info",
-				title: result.added ? "Torrent added" : "Torrent already added",
-				message: result.name || filename,
-			});
-			this.renderer.requestRender();
-
 			if (result.added) {
 				this.pendingAdd = result;
 				this.openCategorySelectForAdd();
+			} else {
+				this.renderer.requestRender();
 			}
 		} catch (err) {
 			this.toastManager.show({
@@ -376,6 +372,12 @@ export class App {
 					this.clearCategoryFlow();
 					return;
 				}
+				this.toastManager.show({
+					id: `added-${Date.now()}`,
+					type: "success",
+					title: "Torrent added",
+					message: result.name,
+				});
 				const torrent = this.store
 					.getState()
 					.torrents.find((t) => t.id === result.id);

--- a/src/cli/info.ts
+++ b/src/cli/info.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
-import { decode, type BencodeValue } from "../torrent/parser";
 import { TorrentMetadata } from "../torrent/metadata";
+import { type BencodeValue, decode } from "../torrent/parser";
 
 export interface TorrentInfoFile {
 	path: string;
@@ -43,7 +43,9 @@ export function torrentInfoFromBytes(raw: Uint8Array): TorrentInfo {
 	);
 }
 
-export function torrentInfoFromMetadata(metadata: TorrentMetadata): TorrentInfo {
+export function torrentInfoFromMetadata(
+	metadata: TorrentMetadata,
+): TorrentInfo {
 	return {
 		name: metadata.name,
 		infoHash: Buffer.from(metadata.infoHash).toString("hex"),

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -54,13 +54,17 @@ export function parseCliArgs(args: string[]): CliCommand {
 
 	const inputs = args.filter((arg) => !VALUELESS_FLAGS.has(arg));
 	if (inputs.length > 1) {
-		throw new Error(`Expected one torrent or magnet argument, got ${inputs.length}`);
+		throw new Error(
+			`Expected one torrent or magnet argument, got ${inputs.length}`,
+		);
 	}
 
 	const input = inputs[0];
 	const action = actions[0] ?? "tui";
 	if (action !== "tui" && !input) {
-		throw new Error(`Missing torrent or magnet argument for ${flagForAction(action)}`);
+		throw new Error(
+			`Missing torrent or magnet argument for ${flagForAction(action)}`,
+		);
 	}
 
 	return { action, input, json };

--- a/src/config/categories.ts
+++ b/src/config/categories.ts
@@ -1,0 +1,116 @@
+import type { AppSettings, CategorySettings } from "./settings";
+
+export interface CategoryInput {
+	name: string;
+	savePath?: string | null;
+}
+
+export function createCategory(
+	existing: readonly CategorySettings[],
+	input: CategoryInput,
+): CategorySettings {
+	const name = uniqueCategoryName(normalizeCategoryName(input.name), existing);
+	const id = uniqueCategoryId(slugifyCategoryName(name), existing);
+	return {
+		id,
+		name,
+		savePath: normalizeCategorySavePath(input.savePath),
+	};
+}
+
+export function updateCategory(
+	existing: readonly CategorySettings[],
+	id: string,
+	input: CategoryInput,
+): CategorySettings[] {
+	const target = existing.find((category) => category.id === id);
+	if (!target) return [...existing];
+	const others = existing.filter((category) => category.id !== id);
+	const name = uniqueCategoryName(normalizeCategoryName(input.name), others);
+	return existing.map((category) =>
+		category.id === id
+			? {
+					...category,
+					name,
+					savePath: normalizeCategorySavePath(input.savePath),
+				}
+			: category,
+	);
+}
+
+export function normalizeCategories(
+	categories: readonly CategorySettings[],
+): CategorySettings[] {
+	const normalized: CategorySettings[] = [];
+	for (const category of categories) {
+		const name = normalizeCategoryName(category.name);
+		if (!name) continue;
+		if (
+			normalized.some(
+				(existing) => existing.name.toLowerCase() === name.toLowerCase(),
+			)
+		) {
+			continue;
+		}
+		const baseId = category.id.trim() || slugifyCategoryName(name);
+		normalized.push({
+			id: uniqueCategoryId(baseId, normalized),
+			name,
+			savePath: normalizeCategorySavePath(category.savePath),
+		});
+	}
+	return normalized;
+}
+
+export function normalizeCategorySettings(settings: AppSettings): AppSettings {
+	const categories = normalizeCategories(settings.categories);
+	const defaultCategoryId = categories.some(
+		(category) => category.id === settings.defaultCategoryId,
+	)
+		? settings.defaultCategoryId
+		: null;
+	return { ...settings, categories, defaultCategoryId };
+}
+
+export function normalizeCategoryName(name: string): string {
+	return name.trim().replace(/\s+/g, " ");
+}
+
+export function normalizeCategorySavePath(path: string | null | undefined) {
+	const trimmed = path?.trim() ?? "";
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function slugifyCategoryName(name: string): string {
+	const slug = name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return slug || "category";
+}
+
+function uniqueCategoryId(
+	baseId: string,
+	existing: readonly CategorySettings[],
+): string {
+	const base = baseId || "category";
+	const taken = new Set(existing.map((category) => category.id));
+	if (!taken.has(base)) return base;
+	let suffix = 2;
+	while (taken.has(`${base}-${suffix}`)) suffix++;
+	return `${base}-${suffix}`;
+}
+
+function uniqueCategoryName(
+	name: string,
+	existing: readonly CategorySettings[],
+): string {
+	const base = name || "Category";
+	const taken = new Set(
+		existing.map((category) => category.name.trim().toLowerCase()),
+	);
+	if (!taken.has(base.toLowerCase())) return base;
+	let suffix = 2;
+	while (taken.has(`${base} ${suffix}`.toLowerCase())) suffix++;
+	return `${base} ${suffix}`;
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { log } from "../torrent/metadata";
 import { writeJsonAtomic } from "../utils/json";
 import { getConfigPath } from "../utils/paths";
+import { normalizeCategorySettings } from "./categories";
 import { type AppSettings, DEFAULT_SETTINGS, settingsSchema } from "./settings";
 
 const SETTINGS_FILE = "settings.json";
@@ -23,7 +24,7 @@ export function loadConfig(): AppSettings {
 		const result = settingsSchema.safeParse(raw);
 
 		if (result.success) {
-			return result.data;
+			return normalizeCategorySettings(result.data);
 		}
 
 		log("config", "invalid settings file — using defaults");
@@ -35,5 +36,8 @@ export function loadConfig(): AppSettings {
 }
 
 export function saveConfig(settings: AppSettings): void {
-	writeJsonAtomic(getConfigPath(SETTINGS_FILE), settings);
+	writeJsonAtomic(
+		getConfigPath(SETTINGS_FILE),
+		normalizeCategorySettings(settings),
+	);
 }

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -1,9 +1,17 @@
 import { z } from "zod";
 
+export const categorySettingsSchema = z.object({
+	id: z.string().min(1),
+	name: z.string().min(1),
+	savePath: z.string().nullable().default(null),
+});
+
 export const settingsSchema = z.object({
 	downloadPath: z.string().default("~/Downloads"),
 	maxConnections: z.number().min(1).max(500).default(50),
 	torrentFolder: z.string().default("~/Downloads"),
+	categories: z.array(categorySettingsSchema).default([]),
+	defaultCategoryId: z.string().nullable().default(null),
 	downloadRateLimitBps: z.number().min(0).default(0),
 	uploadRateLimitBps: z.number().min(0).default(0),
 	enableWebSeeds: z.boolean().default(true),
@@ -18,11 +26,14 @@ export const settingsSchema = z.object({
 });
 
 export type AppSettings = z.infer<typeof settingsSchema>;
+export type CategorySettings = z.infer<typeof categorySettingsSchema>;
 
 export const DEFAULT_SETTINGS: AppSettings = {
 	downloadPath: "~/Downloads",
 	maxConnections: 50,
 	torrentFolder: "~/Downloads",
+	categories: [],
+	defaultCategoryId: null,
 	downloadRateLimitBps: 0,
 	uploadRateLimitBps: 0,
 	enableWebSeeds: true,

--- a/src/controllers/app-controller.ts
+++ b/src/controllers/app-controller.ts
@@ -1,5 +1,4 @@
 import type { CliRenderer, KeyEvent, PasteEvent } from "@opentui/core";
-import { SIDEBAR_ITEMS } from "../constants";
 import type { ConfirmDialog } from "../layout/confirm-dialog";
 import type { ContentWindow, FocusArea } from "../layout/content-window";
 import {
@@ -7,13 +6,13 @@ import {
 	FILE_TAB_FIXED_LINES,
 	getDetailMaxScrollOffset,
 } from "../layout/detail-panel";
-import type { Sidebar } from "../layout/sidebar";
+import { buildSidebarSelectableItems, type Sidebar } from "../layout/sidebar";
 import type { StatusBar } from "../layout/status-bar";
 import type { ToastManager } from "../layout/toast-manager";
 import type { Store } from "../store";
 import { filterTorrents } from "../utils/filter";
 
-type FocusMode = "global" | "dialog";
+type FocusMode = "global" | "dialog" | "search";
 const DETAIL_TABS: DetailTab[] = ["Pieces", "Peers", "Files"];
 
 export class AppController {
@@ -46,12 +45,23 @@ export class AppController {
 	onResumeTorrent?: (id: string) => Promise<void> | void;
 	onStartTorrent?: (id: string) => Promise<void> | void;
 	onRemoveTorrent?: (id: string, deleteFiles: boolean) => Promise<void> | void;
+	onSetTorrentCategory?: (id: string) => Promise<void> | void;
+	onManageCategories?: () => Promise<void> | void;
 
 	private _confirmDialog: ConfirmDialog | null = null;
+	private pendingConfirmAction: (() => Promise<void> | void) | null = null;
+	private pendingConfirmCancel: (() => void) | null = null;
 	set confirmDialog(dialog: ConfirmDialog) {
 		this._confirmDialog = dialog;
 		dialog.onConfirm = () => {
 			this.focusMode = "global";
+			const confirmAction = this.pendingConfirmAction;
+			if (confirmAction) {
+				this.pendingConfirmAction = null;
+				this.pendingConfirmCancel = null;
+				this.runTorrentAction("confirm action", confirmAction);
+				return;
+			}
 			const pendingDeleteId = this.pendingDeleteId;
 			if (pendingDeleteId) {
 				this.runTorrentAction("remove torrent", () =>
@@ -62,6 +72,10 @@ export class AppController {
 		};
 		dialog.onCancel = () => {
 			this.focusMode = "global";
+			const cancelAction = this.pendingConfirmCancel;
+			this.pendingConfirmAction = null;
+			this.pendingConfirmCancel = null;
+			cancelAction?.();
 			this.pendingDeleteId = null;
 		};
 	}
@@ -84,7 +98,7 @@ export class AppController {
 
 	start(): void {
 		this.store.subscribe((state) => {
-			const len = filterTorrents(state.torrents, state.selectedView).length;
+			const len = this.getVisibleTorrents(state).length;
 			if (len > 0 && this.tableSelectedIndex >= len) {
 				this.tableSelectedIndex = len - 1;
 			} else if (len === 0) {
@@ -99,7 +113,7 @@ export class AppController {
 				this.getDetailScrollOffset(),
 				this.filesTabCursor,
 			);
-			this.statusBar.update(state, this.focusArea);
+			this.statusBar.update(state, this.focusArea, this.focusMode === "search");
 		});
 
 		this.renderer.keyInput.on("keypress", (key) => {
@@ -112,6 +126,18 @@ export class AppController {
 		this.refreshView();
 	}
 
+	confirm(
+		message: string,
+		detail: string,
+		onConfirm: () => Promise<void> | void,
+		onCancel?: () => void,
+	): void {
+		this.pendingConfirmAction = onConfirm;
+		this.pendingConfirmCancel = onCancel ?? null;
+		this.focusMode = "dialog";
+		this._confirmDialog?.open(message, detail);
+	}
+
 	private refreshView(): void {
 		const state = this.store.getState();
 		this.sidebar.update(state, this.focusArea);
@@ -122,7 +148,7 @@ export class AppController {
 			this.getDetailScrollOffset(),
 			this.filesTabCursor,
 		);
-		this.statusBar.update(state, this.focusArea);
+		this.statusBar.update(state, this.focusArea, this.focusMode === "search");
 	}
 
 	private runTorrentAction(
@@ -143,11 +169,14 @@ export class AppController {
 
 	private getSelectedId(): string | null {
 		const state = this.store.getState();
-		return (
-			filterTorrents(state.torrents, state.selectedView)[
-				this.tableSelectedIndex
-			]?.id ?? null
-		);
+		return this.getVisibleTorrents(state)[this.tableSelectedIndex]?.id ?? null;
+	}
+
+	private getVisibleTorrents(state = this.store.getState()) {
+		return filterTorrents(state.torrents, {
+			view: state.selectedView,
+			searchQuery: state.searchQuery,
+		});
 	}
 
 	private getDetailTab(): DetailTab {
@@ -178,11 +207,7 @@ export class AppController {
 
 	private getSelectedTorrent() {
 		const state = this.store.getState();
-		return (
-			filterTorrents(state.torrents, state.selectedView)[
-				this.tableSelectedIndex
-			] ?? null
-		);
+		return this.getVisibleTorrents(state)[this.tableSelectedIndex] ?? null;
 	}
 
 	private syncDetailState(): void {
@@ -218,6 +243,38 @@ export class AppController {
 	}
 
 	private handleKeyPress(key: KeyEvent): void {
+		if (this.focusMode === "search") {
+			if (key.name === "escape") {
+				this.focusMode = "global";
+				this.store.setState({ searchQuery: "" });
+				key.preventDefault();
+				key.stopPropagation();
+				return;
+			}
+			if (key.name === "return" || key.name === "enter") {
+				this.focusMode = "global";
+				this.refreshView();
+				key.preventDefault();
+				key.stopPropagation();
+				return;
+			}
+			if (key.name === "backspace") {
+				const query = this.store.getState().searchQuery;
+				this.store.setState({ searchQuery: query.slice(0, -1) });
+				key.preventDefault();
+				key.stopPropagation();
+				return;
+			}
+			const char = searchCharFromKey(key);
+			if (char) {
+				const query = this.store.getState().searchQuery;
+				this.store.setState({ searchQuery: `${query}${char}` });
+				key.preventDefault();
+				key.stopPropagation();
+			}
+			return;
+		}
+
 		if (this.focusMode === "dialog") {
 			if (this._confirmDialog?.getIsOpen()) {
 				if (this._confirmDialog.handleInput(key.name)) {
@@ -226,7 +283,6 @@ export class AppController {
 				}
 			} else {
 				if (key.name === "escape") {
-					this.focusMode = "global";
 					this.onDialogClose?.();
 					key.preventDefault();
 					key.stopPropagation();
@@ -256,6 +312,15 @@ export class AppController {
 			return;
 		}
 
+		if (key.name === "/") {
+			this.focusMode = "search";
+			this.focusArea = "table";
+			this.refreshView();
+			key.preventDefault();
+			key.stopPropagation();
+			return;
+		}
+
 		if (this.focusArea === "details") {
 			if (
 				key.name === "h" ||
@@ -279,16 +344,17 @@ export class AppController {
 
 		if (key.name === "j" || key.name === "down") {
 			if (this.focusArea === "sidebar") {
-				const total = SIDEBAR_ITEMS.status.length;
 				const state = this.store.getState();
+				const total = buildSidebarSelectableItems().length;
 				const next = (state.selectedIndex + 1) % total;
+				const item = buildSidebarSelectableItems()[next];
 				this.store.setState({
 					selectedIndex: next,
-					selectedView: SIDEBAR_ITEMS.status[next] ?? "All",
+					selectedView: item?.selectedView ?? state.selectedView,
 				});
 			} else if (this.focusArea === "table") {
 				const state = this.store.getState();
-				const len = filterTorrents(state.torrents, state.selectedView).length;
+				const len = this.getVisibleTorrents(state).length;
 				if (len > 0) {
 					this.tableSelectedIndex = Math.min(
 						this.tableSelectedIndex + 1,
@@ -305,12 +371,13 @@ export class AppController {
 			}
 		} else if (key.name === "k" || key.name === "up") {
 			if (this.focusArea === "sidebar") {
-				const total = SIDEBAR_ITEMS.status.length;
 				const state = this.store.getState();
+				const total = buildSidebarSelectableItems().length;
 				const prev = (state.selectedIndex - 1 + total) % total;
+				const item = buildSidebarSelectableItems()[prev];
 				this.store.setState({
 					selectedIndex: prev,
-					selectedView: SIDEBAR_ITEMS.status[prev] ?? "All",
+					selectedView: item?.selectedView ?? state.selectedView,
 				});
 			} else if (this.focusArea === "table") {
 				if (this.tableSelectedIndex > 0) {
@@ -329,9 +396,7 @@ export class AppController {
 				const id = this.getSelectedId();
 				if (!id) return;
 				const state = this.store.getState();
-				const torrent = filterTorrents(state.torrents, state.selectedView)[
-					this.tableSelectedIndex
-				];
+				const torrent = this.getVisibleTorrents(state)[this.tableSelectedIndex];
 				if (!torrent) return;
 				if (torrent.status === "downloading") {
 					this.runTorrentAction("pause torrent", () =>
@@ -368,6 +433,20 @@ export class AppController {
 				this.focusMode = "dialog";
 				this._confirmDialog?.open("Delete torrent and files?");
 			}
+		} else if (key.name === "c") {
+			if (this.focusArea === "table") {
+				const id = this.getSelectedId();
+				if (id)
+					this.runTorrentAction("set torrent category", () =>
+						this.onSetTorrentCategory?.(id),
+					);
+			}
+		} else if (key.name === "m") {
+			if (this.focusArea === "sidebar") {
+				this.runTorrentAction("manage categories", () =>
+					this.onManageCategories?.(),
+				);
+			}
 		} else if (key.name === "a") {
 			this.focusMode = "dialog";
 			this.onAddTorrent?.();
@@ -401,6 +480,13 @@ export class AppController {
 	}
 
 	private handlePaste(event: PasteEvent): void {
+		if (this.focusMode === "search") {
+			this.store.setState({
+				searchQuery: `${this.store.getState().searchQuery}${Buffer.from(event.bytes).toString("utf-8")}`,
+			});
+			event.preventDefault();
+			return;
+		}
 		if (this.focusMode !== "dialog" || this._confirmDialog?.getIsOpen()) return;
 		if (this.onDialogPaste?.(event)) {
 			event.preventDefault();
@@ -428,4 +514,12 @@ export class AppController {
 				return "table";
 		}
 	}
+}
+
+function searchCharFromKey(key: KeyEvent): string {
+	if (key.ctrl || key.meta) return "";
+	if (key.name === "space") return " ";
+	if (key.name.length !== 1) return "";
+	if (key.shift && /^[a-z]$/.test(key.name)) return key.name.toUpperCase();
+	return key.name;
 }

--- a/src/controllers/app-controller.ts
+++ b/src/controllers/app-controller.ts
@@ -37,6 +37,7 @@ export class AppController {
 	private filesTabCursor = 0;
 	private renderTimer: ReturnType<typeof setTimeout> | null = null;
 	private lastRenderAt = 0;
+	private stopped = false;
 
 	// Injected by App after bridge/dialog are created
 	onAddTorrent?: () => void;
@@ -100,6 +101,7 @@ export class AppController {
 	}
 
 	start(): void {
+		this.stopped = false;
 		this.store.subscribe(() => this.scheduleRender());
 
 		this.renderer.keyInput.on("keypress", (key) => {
@@ -110,6 +112,14 @@ export class AppController {
 		});
 
 		this.refreshView();
+	}
+
+	stop(): void {
+		this.stopped = true;
+		if (this.renderTimer) {
+			clearTimeout(this.renderTimer);
+			this.renderTimer = null;
+		}
 	}
 
 	confirm(
@@ -125,6 +135,7 @@ export class AppController {
 	}
 
 	private refreshView(): void {
+		if (this.stopped) return;
 		if (this.renderTimer) {
 			clearTimeout(this.renderTimer);
 			this.renderTimer = null;
@@ -133,16 +144,19 @@ export class AppController {
 	}
 
 	private scheduleRender(): void {
+		if (this.stopped) return;
 		if (this.renderTimer) return;
 		const elapsed = Date.now() - this.lastRenderAt;
 		const delay = Math.max(0, RENDER_THROTTLE_MS - elapsed);
 		this.renderTimer = setTimeout(() => {
 			this.renderTimer = null;
+			if (this.stopped) return;
 			this.renderView();
 		}, delay);
 	}
 
 	private renderView(): void {
+		if (this.stopped) return;
 		this.lastRenderAt = Date.now();
 		const state = this.store.getState();
 		const len = this.getVisibleTorrents(state).length;

--- a/src/controllers/app-controller.ts
+++ b/src/controllers/app-controller.ts
@@ -9,11 +9,12 @@ import {
 import { buildSidebarSelectableItems, type Sidebar } from "../layout/sidebar";
 import type { StatusBar } from "../layout/status-bar";
 import type { ToastManager } from "../layout/toast-manager";
-import type { Store } from "../store";
+import type { AppState, Store } from "../store";
 import { filterTorrents } from "../utils/filter";
 
 type FocusMode = "global" | "dialog" | "search";
 const DETAIL_TABS: DetailTab[] = ["Pieces", "Peers", "Files"];
+const RENDER_THROTTLE_MS = 100;
 
 export class AppController {
 	private renderer: CliRenderer;
@@ -34,6 +35,8 @@ export class AppController {
 	private lastDetailTorrentId: string | null = null;
 	private pendingDeleteId: string | null = null;
 	private filesTabCursor = 0;
+	private renderTimer: ReturnType<typeof setTimeout> | null = null;
+	private lastRenderAt = 0;
 
 	// Injected by App after bridge/dialog are created
 	onAddTorrent?: () => void;
@@ -97,24 +100,7 @@ export class AppController {
 	}
 
 	start(): void {
-		this.store.subscribe((state) => {
-			const len = this.getVisibleTorrents(state).length;
-			if (len > 0 && this.tableSelectedIndex >= len) {
-				this.tableSelectedIndex = len - 1;
-			} else if (len === 0) {
-				this.tableSelectedIndex = 0;
-			}
-			this.syncDetailState();
-			this.sidebar.update(state, this.focusArea);
-			this.contentWindow.update(
-				this.focusArea,
-				this.tableSelectedIndex,
-				this.getDetailTab(),
-				this.getDetailScrollOffset(),
-				this.filesTabCursor,
-			);
-			this.statusBar.update(state, this.focusArea, this.focusMode === "search");
-		});
+		this.store.subscribe(() => this.scheduleRender());
 
 		this.renderer.keyInput.on("keypress", (key) => {
 			this.handleKeyPress(key);
@@ -139,7 +125,33 @@ export class AppController {
 	}
 
 	private refreshView(): void {
+		if (this.renderTimer) {
+			clearTimeout(this.renderTimer);
+			this.renderTimer = null;
+		}
+		this.renderView();
+	}
+
+	private scheduleRender(): void {
+		if (this.renderTimer) return;
+		const elapsed = Date.now() - this.lastRenderAt;
+		const delay = Math.max(0, RENDER_THROTTLE_MS - elapsed);
+		this.renderTimer = setTimeout(() => {
+			this.renderTimer = null;
+			this.renderView();
+		}, delay);
+	}
+
+	private renderView(): void {
+		this.lastRenderAt = Date.now();
 		const state = this.store.getState();
+		const len = this.getVisibleTorrents(state).length;
+		if (len > 0 && this.tableSelectedIndex >= len) {
+			this.tableSelectedIndex = len - 1;
+		} else if (len === 0) {
+			this.tableSelectedIndex = 0;
+		}
+		this.syncDetailState(state);
 		this.sidebar.update(state, this.focusArea);
 		this.contentWindow.update(
 			this.focusArea,
@@ -186,7 +198,7 @@ export class AppController {
 	private moveDetailTab(delta: number): void {
 		this.detailTabIndex =
 			(this.detailTabIndex + delta + DETAIL_TABS.length) % DETAIL_TABS.length;
-		this.refreshView();
+		this.scheduleRender();
 	}
 
 	private getDetailScrollOffset(): number {
@@ -205,20 +217,20 @@ export class AppController {
 		};
 	}
 
-	private getSelectedTorrent() {
-		const state = this.store.getState();
+	private getSelectedTorrent(state = this.store.getState()) {
 		return this.getVisibleTorrents(state)[this.tableSelectedIndex] ?? null;
 	}
 
-	private syncDetailState(): void {
-		const torrentId = this.getSelectedTorrent()?.id ?? null;
+	private syncDetailState(state: AppState = this.store.getState()): void {
+		const selectedTorrent = this.getSelectedTorrent(state);
+		const torrentId = selectedTorrent?.id ?? null;
 		if (torrentId !== this.lastDetailTorrentId) {
 			this.lastDetailTorrentId = torrentId;
 			this.resetDetailScrollOffsets();
 			this.filesTabCursor = 0;
 		}
 		const maxOffset = getDetailMaxScrollOffset(
-			this.getSelectedTorrent(),
+			selectedTorrent,
 			this.getDetailTab(),
 			this.contentWindow.getDetailBodyRowCount(),
 		);
@@ -239,7 +251,7 @@ export class AppController {
 		);
 		if (nextOffset === this.getDetailScrollOffset()) return;
 		this.setDetailScrollOffset(nextOffset);
-		this.refreshView();
+		this.scheduleRender();
 	}
 
 	private handleKeyPress(key: KeyEvent): void {
@@ -253,7 +265,7 @@ export class AppController {
 			}
 			if (key.name === "return" || key.name === "enter") {
 				this.focusMode = "global";
-				this.refreshView();
+				this.scheduleRender();
 				key.preventDefault();
 				key.stopPropagation();
 				return;
@@ -302,20 +314,24 @@ export class AppController {
 
 		if (key.shift && key.name === "tab") {
 			this.focusArea = this.previousFocusArea();
-			this.refreshView();
+			this.scheduleRender();
+			key.preventDefault();
+			key.stopPropagation();
 			return;
 		}
 
 		if (key.name === "tab") {
 			this.focusArea = this.nextFocusArea();
-			this.refreshView();
+			this.scheduleRender();
+			key.preventDefault();
+			key.stopPropagation();
 			return;
 		}
 
 		if (key.name === "/") {
 			this.focusMode = "search";
 			this.focusArea = "table";
-			this.refreshView();
+			this.scheduleRender();
 			key.preventDefault();
 			key.stopPropagation();
 			return;
@@ -360,7 +376,7 @@ export class AppController {
 						this.tableSelectedIndex + 1,
 						len - 1,
 					);
-					this.refreshView();
+					this.scheduleRender();
 				}
 			} else if (this.focusArea === "details") {
 				if (this.getDetailTab() === "Files") {
@@ -382,7 +398,7 @@ export class AppController {
 			} else if (this.focusArea === "table") {
 				if (this.tableSelectedIndex > 0) {
 					this.tableSelectedIndex--;
-					this.refreshView();
+					this.scheduleRender();
 				}
 			} else if (this.focusArea === "details") {
 				if (this.getDetailTab() === "Files") {
@@ -476,7 +492,7 @@ export class AppController {
 			this.detailScrollOffsets.Files = this.filesTabCursor;
 		}
 
-		this.refreshView();
+		this.scheduleRender();
 	}
 
 	private handlePaste(event: PasteEvent): void {

--- a/src/layout/category-dialog.ts
+++ b/src/layout/category-dialog.ts
@@ -1,0 +1,230 @@
+import {
+	BoxRenderable,
+	type CliRenderer,
+	type KeyEvent,
+	TextRenderable,
+} from "@opentui/core";
+import { getTheme } from "../theme";
+import type { LayoutDimensions } from "../types/layout";
+import { resolvePath } from "../utils/paths";
+
+const DIALOG_WIDTH = 62;
+const DIALOG_HEIGHT = 12;
+const INNER_W = DIALOG_WIDTH - 2;
+const MARGIN = 2;
+
+export interface CategoryDialogResult {
+	name: string;
+	savePath: string | null;
+}
+
+export interface CategoryDialogOpenOptions {
+	name?: string;
+	savePath?: string | null;
+	title?: string;
+}
+
+function setText(node: TextRenderable, content: string): void {
+	(node as unknown as { content: string }).content = content;
+}
+
+function setFg(node: TextRenderable, fg: string): void {
+	(node as unknown as { fg: string }).fg = fg;
+}
+
+function truncateMiddle(text: string, max: number): string {
+	if (text.length <= max) return text;
+	if (max <= 1) return "…";
+	const left = Math.floor((max - 1) / 2);
+	const right = max - 1 - left;
+	return `${text.slice(0, left)}…${text.slice(-right)}`;
+}
+
+export class CategoryDialog {
+	private renderer: CliRenderer;
+	private layout: LayoutDimensions;
+	private container: BoxRenderable | null = null;
+	private titleText: TextRenderable | null = null;
+	private nameText: TextRenderable | null = null;
+	private pathText: TextRenderable | null = null;
+	private hintText: TextRenderable | null = null;
+	private isOpen = false;
+	private name = "";
+	private savePath: string | null = null;
+	private initialBrowsePath = "";
+	private title = "New category";
+
+	onBrowse?: (initialPath: string) => void;
+	onCancel?: () => void;
+	onConfirm?: (result: CategoryDialogResult) => void;
+
+	constructor(renderer: CliRenderer, layout: LayoutDimensions) {
+		this.renderer = renderer;
+		this.layout = layout;
+		this.createElements();
+	}
+
+	open(
+		initialBrowsePath: string,
+		options: CategoryDialogOpenOptions = {},
+	): void {
+		this.isOpen = true;
+		this.name = options.name ?? "";
+		this.savePath = options.savePath ? resolvePath(options.savePath) : null;
+		this.title = options.title ?? "New category";
+		this.initialBrowsePath = resolvePath(initialBrowsePath);
+		this.updatePosition();
+		this.render();
+		if (this.container) this.container.visible = true;
+	}
+
+	close(): void {
+		if (!this.isOpen) return;
+		this.isOpen = false;
+		if (this.container) this.container.visible = false;
+	}
+
+	hide(): void {
+		if (this.container) this.container.visible = false;
+	}
+
+	show(): void {
+		if (!this.isOpen) return;
+		this.updatePosition();
+		this.render();
+		if (this.container) this.container.visible = true;
+	}
+
+	getIsOpen(): boolean {
+		return this.isOpen;
+	}
+
+	setSavePath(path: string): void {
+		this.savePath = resolvePath(path);
+		this.render();
+	}
+
+	handleInput(key: KeyEvent): boolean {
+		if (!this.isOpen) return false;
+		if (key.name === "escape") {
+			this.close();
+			this.onCancel?.();
+			return true;
+		}
+		if (key.name === "backspace") {
+			this.name = this.name.slice(0, -1);
+			this.render();
+			return true;
+		}
+		if (key.name === "b") {
+			this.onBrowse?.(this.savePath ?? this.initialBrowsePath);
+			return true;
+		}
+		if (key.name === "x") {
+			this.savePath = null;
+			this.render();
+			return true;
+		}
+		if (key.name === "return" || key.name === "enter") {
+			const name = this.name.trim();
+			if (name.length === 0) return true;
+			const savePath = this.savePath;
+			this.close();
+			this.onConfirm?.({ name, savePath });
+			return true;
+		}
+		const char = charFromKey(key);
+		if (char) {
+			this.name += char;
+			this.render();
+		}
+		return true;
+	}
+
+	updateLayout(layout: LayoutDimensions): void {
+		this.layout = layout;
+		if (this.isOpen) this.updatePosition();
+	}
+
+	private render(): void {
+		const theme = getTheme();
+		if (this.titleText) setText(this.titleText, this.title);
+		if (this.nameText) {
+			setText(this.nameText, `Name: ${this.name}█`);
+			setFg(this.nameText, theme.accent);
+		}
+		if (this.pathText) {
+			const path = this.savePath
+				? truncateMiddle(this.savePath, INNER_W - 10)
+				: "none";
+			setText(this.pathText, `Path: ${path}`);
+			setFg(this.pathText, this.savePath ? theme.fgPrimary : theme.fgMuted);
+		}
+		if (this.hintText) {
+			setText(
+				this.hintText,
+				"b browse path  x clear path  Enter save  Esc cancel",
+			);
+		}
+	}
+
+	private updatePosition(): void {
+		if (!this.container) return;
+		this.container.left = Math.max(
+			0,
+			Math.floor((this.layout.terminal.width - DIALOG_WIDTH) / 2),
+		);
+		this.container.top = Math.max(
+			0,
+			Math.floor((this.layout.terminal.height - DIALOG_HEIGHT) / 2),
+		);
+	}
+
+	private createElements(): void {
+		const theme = getTheme();
+		const container = new BoxRenderable(this.renderer, {
+			position: "absolute",
+			left: 0,
+			top: 0,
+			width: DIALOG_WIDTH,
+			height: DIALOG_HEIGHT,
+			border: true,
+			borderStyle: "single",
+			borderColor: theme.accent,
+			backgroundColor: theme.bgPrimary,
+			visible: false,
+			flexDirection: "column",
+		});
+		for (const [index, assign] of [
+			[0, (text: TextRenderable) => (this.titleText = text)],
+			[2, (text: TextRenderable) => (this.nameText = text)],
+			[4, (text: TextRenderable) => (this.pathText = text)],
+			[8, (text: TextRenderable) => (this.hintText = text)],
+		] as const) {
+			const row = new BoxRenderable(this.renderer, {
+				width: INNER_W,
+				height: 1,
+				paddingLeft: MARGIN,
+				paddingRight: MARGIN,
+				marginTop: index === 0 ? 0 : 1,
+			});
+			const text = new TextRenderable(this.renderer, {
+				content: "",
+				fg: index === 0 ? theme.accent : theme.fgPrimary,
+			});
+			assign(text);
+			row.add(text);
+			container.add(row);
+		}
+		this.renderer.root.add(container);
+		this.container = container;
+	}
+}
+
+function charFromKey(key: KeyEvent): string {
+	if (key.ctrl || key.meta) return "";
+	if (key.name === "space") return " ";
+	if (key.name.length !== 1) return "";
+	if (key.shift && /^[a-z]$/.test(key.name)) return key.name.toUpperCase();
+	return key.name;
+}

--- a/src/layout/category-manager-dialog.ts
+++ b/src/layout/category-manager-dialog.ts
@@ -1,0 +1,279 @@
+import { homedir } from "node:os";
+import {
+	BoxRenderable,
+	type CliRenderer,
+	type KeyEvent,
+	TextRenderable,
+} from "@opentui/core";
+import type { CategoryState } from "../store";
+import { getTheme } from "../theme";
+import type { LayoutDimensions } from "../types/layout";
+
+const DIALOG_WIDTH = 58;
+const DIALOG_HEIGHT = 18;
+const INNER_W = DIALOG_WIDTH - 2;
+const MARGIN = 2;
+const ROWS = 11;
+
+interface Row {
+	container: BoxRenderable;
+	text: TextRenderable;
+}
+
+function setText(node: TextRenderable, content: string): void {
+	(node as unknown as { content: string }).content = content;
+}
+
+function setFg(node: TextRenderable, fg: string): void {
+	(node as unknown as { fg: string }).fg = fg;
+}
+
+function setBg(node: BoxRenderable, bg: string | undefined): void {
+	(node as unknown as { backgroundColor: string | undefined }).backgroundColor =
+		bg;
+}
+
+function truncateMiddle(text: string, max: number): string {
+	if (text.length <= max) return text;
+	if (max <= 1) return "…";
+	const left = Math.floor((max - 1) / 2);
+	const right = max - 1 - left;
+	return `${text.slice(0, left)}…${text.slice(-right)}`;
+}
+
+function truncateRight(text: string, max: number): string {
+	if (text.length <= max) return text;
+	if (max <= 1) return "…";
+	return `${text.slice(0, max - 1)}…`;
+}
+
+function abbreviateHomePath(path: string): string {
+	const trimmed = path.trim();
+	const normalizedPath = trimmed.replace(/\\/g, "/");
+	const normalizedHome = homedir().replace(/\\/g, "/");
+	if (normalizedPath === normalizedHome) return "~";
+	if (normalizedPath.startsWith(`${normalizedHome}/`)) {
+		return `~${normalizedPath.slice(normalizedHome.length)}`;
+	}
+	return trimmed;
+}
+
+export class CategoryManagerDialog {
+	private renderer: CliRenderer;
+	private layout: LayoutDimensions;
+	private container: BoxRenderable | null = null;
+	private titleText: TextRenderable | null = null;
+	private hintText: TextRenderable | null = null;
+	private rows: Row[] = [];
+	private isOpen = false;
+	private categories: CategoryState[] = [];
+	private cursor = 0;
+	private scrollOffset = 0;
+
+	onCancel?: () => void;
+	onDelete?: (category: CategoryState) => void;
+	onEdit?: (category: CategoryState) => void;
+	onNew?: () => void;
+
+	constructor(renderer: CliRenderer, layout: LayoutDimensions) {
+		this.renderer = renderer;
+		this.layout = layout;
+		this.createElements();
+	}
+
+	open(categories: CategoryState[]): void {
+		this.isOpen = true;
+		this.categories = categories;
+		this.cursor = Math.min(this.cursor, Math.max(0, categories.length - 1));
+		this.scrollOffset = 0;
+		this.updatePosition();
+		this.render();
+		if (this.container) this.container.visible = true;
+	}
+
+	close(): void {
+		if (!this.isOpen) return;
+		this.isOpen = false;
+		if (this.container) this.container.visible = false;
+	}
+
+	hide(): void {
+		if (this.container) this.container.visible = false;
+	}
+
+	show(categories = this.categories): void {
+		if (!this.isOpen) return;
+		this.categories = categories;
+		this.cursor = Math.min(this.cursor, Math.max(0, categories.length - 1));
+		this.updatePosition();
+		this.render();
+		if (this.container) this.container.visible = true;
+	}
+
+	getIsOpen(): boolean {
+		return this.isOpen;
+	}
+
+	handleInput(key: KeyEvent): boolean {
+		if (!this.isOpen) return false;
+		if (key.name === "escape") {
+			this.close();
+			this.onCancel?.();
+			return true;
+		}
+		if (key.name === "n") {
+			this.onNew?.();
+			return true;
+		}
+		if (key.name === "j" || key.name === "down") {
+			if (this.cursor < this.categories.length - 1) {
+				this.cursor++;
+				this.ensureCursorVisible();
+				this.render();
+			}
+			return true;
+		}
+		if (key.name === "k" || key.name === "up") {
+			if (this.cursor > 0) {
+				this.cursor--;
+				this.ensureCursorVisible();
+				this.render();
+			}
+			return true;
+		}
+		const selected = this.categories[this.cursor];
+		if (
+			(key.name === "e" || key.name === "return" || key.name === "enter") &&
+			selected
+		) {
+			this.onEdit?.(selected);
+			return true;
+		}
+		if (key.name === "d" && selected) {
+			this.onDelete?.(selected);
+			return true;
+		}
+		return true;
+	}
+
+	updateLayout(layout: LayoutDimensions): void {
+		this.layout = layout;
+		if (this.isOpen) this.updatePosition();
+	}
+
+	private ensureCursorVisible(): void {
+		if (this.cursor < this.scrollOffset) {
+			this.scrollOffset = this.cursor;
+		} else if (this.cursor >= this.scrollOffset + ROWS) {
+			this.scrollOffset = this.cursor - ROWS + 1;
+		}
+	}
+
+	private render(): void {
+		const theme = getTheme();
+		if (this.titleText) setText(this.titleText, "Manage categories");
+		for (let i = 0; i < this.rows.length; i++) {
+			const row = this.rows[i];
+			const category = this.categories[this.scrollOffset + i];
+			if (!row) continue;
+			if (!category) {
+				setText(
+					row.text,
+					i === 0 && this.categories.length === 0
+						? `${" ".repeat(MARGIN)}No categories`
+						: "",
+				);
+				setFg(row.text, theme.fgMuted);
+				setBg(row.container, undefined);
+				continue;
+			}
+			const selected = this.scrollOffset + i === this.cursor;
+			setText(row.text, this.formatCategory(category));
+			setFg(row.text, selected ? theme.fgPrimary : theme.fgSecondary);
+			setBg(row.container, selected ? theme.bgTertiary : undefined);
+		}
+		if (this.hintText) {
+			setText(this.hintText, "Enter/e edit  n new  d delete  Esc close");
+		}
+	}
+
+	private formatCategory(category: CategoryState): string {
+		const nameWidth = 18;
+		const pathWidth = INNER_W - MARGIN * 2 - nameWidth - 1;
+		const name = truncateRight(category.name, nameWidth);
+		const path = category.savePath
+			? abbreviateHomePath(category.savePath)
+			: "no default path";
+		return `${" ".repeat(MARGIN)}${name.padEnd(nameWidth)} ${truncateMiddle(path, pathWidth)}`;
+	}
+
+	private updatePosition(): void {
+		if (!this.container) return;
+		this.container.left = Math.max(
+			0,
+			Math.floor((this.layout.terminal.width - DIALOG_WIDTH) / 2),
+		);
+		this.container.top = Math.max(
+			0,
+			Math.floor((this.layout.terminal.height - DIALOG_HEIGHT) / 2),
+		);
+	}
+
+	private createElements(): void {
+		const theme = getTheme();
+		const container = new BoxRenderable(this.renderer, {
+			position: "absolute",
+			left: 0,
+			top: 0,
+			width: DIALOG_WIDTH,
+			height: DIALOG_HEIGHT,
+			border: true,
+			borderStyle: "single",
+			borderColor: theme.accent,
+			backgroundColor: theme.bgPrimary,
+			visible: false,
+			flexDirection: "column",
+		});
+		const titleRow = new BoxRenderable(this.renderer, {
+			width: INNER_W,
+			height: 1,
+			paddingLeft: MARGIN,
+			paddingRight: MARGIN,
+		});
+		this.titleText = new TextRenderable(this.renderer, {
+			content: "",
+			fg: theme.accent,
+		});
+		titleRow.add(this.titleText);
+		container.add(titleRow);
+		container.add(new BoxRenderable(this.renderer, { height: 1 }));
+		for (let i = 0; i < ROWS; i++) {
+			const rowContainer = new BoxRenderable(this.renderer, {
+				width: INNER_W,
+				height: 1,
+			});
+			const text = new TextRenderable(this.renderer, {
+				content: "",
+				fg: theme.fgSecondary,
+			});
+			rowContainer.add(text);
+			container.add(rowContainer);
+			this.rows.push({ container: rowContainer, text });
+		}
+		container.add(new BoxRenderable(this.renderer, { flexGrow: 1 }));
+		const hintRow = new BoxRenderable(this.renderer, {
+			width: INNER_W,
+			height: 1,
+			paddingLeft: MARGIN,
+			paddingRight: MARGIN,
+		});
+		this.hintText = new TextRenderable(this.renderer, {
+			content: "",
+			fg: theme.fgMuted,
+		});
+		hintRow.add(this.hintText);
+		container.add(hintRow);
+		this.renderer.root.add(container);
+		this.container = container;
+	}
+}

--- a/src/layout/category-select-dialog.ts
+++ b/src/layout/category-select-dialog.ts
@@ -1,0 +1,331 @@
+import { homedir } from "node:os";
+import {
+	BoxRenderable,
+	type CliRenderer,
+	type KeyEvent,
+	TextRenderable,
+} from "@opentui/core";
+import type { CategoryState } from "../store";
+import { getTheme } from "../theme";
+import type { LayoutDimensions } from "../types/layout";
+
+const DIALOG_WIDTH = 48;
+const DIALOG_HEIGHT = 16;
+const INNER_W = DIALOG_WIDTH - 2;
+const MARGIN = 2;
+const ROWS = 9;
+
+type CategorySelectMode = "add" | "reassign";
+
+export interface CategorySelectOpenOptions {
+	categories: CategoryState[];
+	currentCategoryId?: string | null;
+	defaultCategoryId?: string | null;
+	globalDownloadPath?: string;
+	mode: CategorySelectMode;
+}
+
+export interface CategorySelectOption {
+	id: string | null;
+	name: string;
+	savePath: string | null;
+}
+
+interface Row {
+	container: BoxRenderable;
+	text: TextRenderable;
+}
+
+function setText(node: TextRenderable, content: string): void {
+	(node as unknown as { content: string }).content = content;
+}
+
+function setFg(node: TextRenderable, fg: string): void {
+	(node as unknown as { fg: string }).fg = fg;
+}
+
+function setBg(node: BoxRenderable, bg: string | undefined): void {
+	(node as unknown as { backgroundColor: string | undefined }).backgroundColor =
+		bg;
+}
+
+function truncateRight(text: string, max: number): string {
+	if (text.length <= max) return text;
+	if (max <= 1) return "…";
+	return `${text.slice(0, max - 1)}…`;
+}
+
+function truncateMiddle(text: string, max: number): string {
+	if (text.length <= max) return text;
+	if (max <= 1) return "…";
+	const left = Math.floor((max - 1) / 2);
+	const right = max - 1 - left;
+	return `${text.slice(0, left)}…${text.slice(-right)}`;
+}
+
+function abbreviateHomePath(path: string): string {
+	const trimmed = path.trim();
+	const normalizedPath = trimmed.replace(/\\/g, "/");
+	const normalizedHome = homedir().replace(/\\/g, "/");
+	if (normalizedPath === normalizedHome) return "~";
+	if (normalizedPath.startsWith(`${normalizedHome}/`)) {
+		return `~${normalizedPath.slice(normalizedHome.length)}`;
+	}
+	return trimmed;
+}
+
+export class CategorySelectDialog {
+	private renderer: CliRenderer;
+	private layout: LayoutDimensions;
+	private container: BoxRenderable | null = null;
+	private titleText: TextRenderable | null = null;
+	private hintText: TextRenderable | null = null;
+	private rows: Row[] = [];
+	private isOpen = false;
+	private categories: CategoryState[] = [];
+	private globalDownloadPath = "";
+	private mode: CategorySelectMode = "reassign";
+	private cursor = 0;
+	private scrollOffset = 0;
+
+	onCancel?: () => void;
+	onNewCategory?: () => void;
+	onSelect?: (category: CategorySelectOption | null) => void;
+
+	constructor(renderer: CliRenderer, layout: LayoutDimensions) {
+		this.renderer = renderer;
+		this.layout = layout;
+		this.createElements();
+	}
+
+	open(options: CategorySelectOpenOptions): void {
+		this.isOpen = true;
+		this.mode = options.mode;
+		this.categories = options.categories;
+		this.globalDownloadPath = options.globalDownloadPath ?? "";
+		this.cursor = this.initialCursor(options);
+		this.scrollOffset = 0;
+		if (this.titleText) setText(this.titleText, "Select category");
+		this.updatePosition();
+		this.render();
+		if (this.container) this.container.visible = true;
+	}
+
+	close(): void {
+		if (!this.isOpen) return;
+		this.isOpen = false;
+		if (this.container) this.container.visible = false;
+	}
+
+	hide(): void {
+		if (this.container) this.container.visible = false;
+	}
+
+	show(): void {
+		if (!this.isOpen) return;
+		this.updatePosition();
+		this.render();
+		if (this.container) this.container.visible = true;
+	}
+
+	getIsOpen(): boolean {
+		return this.isOpen;
+	}
+
+	handleInput(key: KeyEvent): boolean {
+		if (!this.isOpen) return false;
+		if (key.name === "escape") {
+			this.close();
+			this.onCancel?.();
+			return true;
+		}
+		if (key.name === "n") {
+			this.onNewCategory?.();
+			return true;
+		}
+		if (key.name === "b") {
+			return true;
+		}
+		if (key.name === "j" || key.name === "down") {
+			if (this.cursor < this.options().length - 1) {
+				this.cursor++;
+				this.ensureCursorVisible();
+				this.render();
+			}
+			return true;
+		}
+		if (key.name === "k" || key.name === "up") {
+			if (this.cursor > 0) {
+				this.cursor--;
+				this.ensureCursorVisible();
+				this.render();
+			}
+			return true;
+		}
+		if (key.name === "return" || key.name === "enter") {
+			const selected = this.options()[this.cursor];
+			this.close();
+			this.onSelect?.(selected?.id ? selected : null);
+			return true;
+		}
+		return true;
+	}
+
+	updateLayout(layout: LayoutDimensions): void {
+		this.layout = layout;
+		if (this.isOpen) this.updatePosition();
+	}
+
+	private options(): CategorySelectOption[] {
+		return [
+			{ id: null, name: "None", savePath: null },
+			...this.categories.map((category) => ({
+				id: category.id,
+				name: category.name,
+				savePath: category.savePath,
+			})),
+		];
+	}
+
+	private initialCursor(options: CategorySelectOpenOptions): number {
+		const selectedId =
+			options.mode === "add"
+				? options.defaultCategoryId
+				: options.currentCategoryId;
+		if (!selectedId) return 0;
+		const index = this.categories.findIndex(
+			(category) => category.id === selectedId,
+		);
+		return index >= 0 ? index + 1 : 0;
+	}
+
+	private ensureCursorVisible(): void {
+		if (this.cursor < this.scrollOffset) {
+			this.scrollOffset = this.cursor;
+		} else if (this.cursor >= this.scrollOffset + ROWS) {
+			this.scrollOffset = this.cursor - ROWS + 1;
+		}
+	}
+
+	private render(): void {
+		const theme = getTheme();
+		const options = this.options();
+		for (let i = 0; i < this.rows.length; i++) {
+			const row = this.rows[i];
+			const option = options[this.scrollOffset + i];
+			if (!row) continue;
+			if (!option) {
+				setText(row.text, "");
+				setBg(row.container, undefined);
+				continue;
+			}
+			const selected = this.scrollOffset + i === this.cursor;
+			setText(row.text, this.formatOption(option));
+			setFg(row.text, selected ? theme.fgPrimary : theme.fgSecondary);
+			setBg(row.container, selected ? theme.bgTertiary : undefined);
+		}
+		if (this.hintText) {
+			const hint =
+				this.mode === "add"
+					? "Enter choose  n new  Esc cancel"
+					: "Enter apply  n new  Esc cancel";
+			setText(this.hintText, hint);
+		}
+	}
+
+	private formatOption(option: CategorySelectOption): string {
+		const nameWidth = 16;
+		const pathWidth = INNER_W - MARGIN * 2 - nameWidth - 1;
+		const name = truncateRight(option.name, nameWidth);
+		const path = this.optionPathLabel(option);
+		return `${" ".repeat(MARGIN)}${name.padEnd(nameWidth)} ${truncateMiddle(path, pathWidth)}`;
+	}
+
+	private optionPathLabel(option: CategorySelectOption): string {
+		if (this.mode === "add") {
+			if (option.id === null)
+				return this.globalDownloadPath
+					? abbreviateHomePath(this.globalDownloadPath)
+					: "global path";
+			return option.savePath
+				? abbreviateHomePath(option.savePath)
+				: this.globalDownloadPath
+					? abbreviateHomePath(this.globalDownloadPath)
+					: "global path";
+		}
+		if (option.id === null) return "uncategorized";
+		return option.savePath
+			? abbreviateHomePath(option.savePath)
+			: "no default path";
+	}
+
+	private updatePosition(): void {
+		if (!this.container) return;
+		this.container.left = Math.max(
+			0,
+			Math.floor((this.layout.terminal.width - DIALOG_WIDTH) / 2),
+		);
+		this.container.top = Math.max(
+			0,
+			Math.floor((this.layout.terminal.height - DIALOG_HEIGHT) / 2),
+		);
+	}
+
+	private createElements(): void {
+		const theme = getTheme();
+		const container = new BoxRenderable(this.renderer, {
+			position: "absolute",
+			left: 0,
+			top: 0,
+			width: DIALOG_WIDTH,
+			height: DIALOG_HEIGHT,
+			border: true,
+			borderStyle: "single",
+			borderColor: theme.accent,
+			backgroundColor: theme.bgPrimary,
+			visible: false,
+			flexDirection: "column",
+		});
+		const titleRow = new BoxRenderable(this.renderer, {
+			width: INNER_W,
+			height: 1,
+			paddingLeft: MARGIN,
+			paddingRight: MARGIN,
+		});
+		this.titleText = new TextRenderable(this.renderer, {
+			content: "",
+			fg: theme.accent,
+		});
+		titleRow.add(this.titleText);
+		container.add(titleRow);
+		container.add(new BoxRenderable(this.renderer, { height: 1 }));
+		for (let i = 0; i < ROWS; i++) {
+			const rowContainer = new BoxRenderable(this.renderer, {
+				width: INNER_W,
+				height: 1,
+			});
+			const text = new TextRenderable(this.renderer, {
+				content: "",
+				fg: theme.fgSecondary,
+			});
+			rowContainer.add(text);
+			container.add(rowContainer);
+			this.rows.push({ container: rowContainer, text });
+		}
+		container.add(new BoxRenderable(this.renderer, { flexGrow: 1 }));
+		const hintRow = new BoxRenderable(this.renderer, {
+			width: INNER_W,
+			height: 1,
+			paddingLeft: MARGIN,
+			paddingRight: MARGIN,
+		});
+		this.hintText = new TextRenderable(this.renderer, {
+			content: "",
+			fg: theme.fgMuted,
+		});
+		hintRow.add(this.hintText);
+		container.add(hintRow);
+		this.renderer.root.add(container);
+		this.container = container;
+	}
+}

--- a/src/layout/confirm-dialog.ts
+++ b/src/layout/confirm-dialog.ts
@@ -22,11 +22,11 @@ export class ConfirmDialog {
 		this.layout = layout;
 	}
 
-	open(message: string): void {
+	open(message: string, detail = "Files will be deleted from disk."): void {
 		if (this.isOpen) return;
 		this.isOpen = true;
 		this.focusedBtn = "cancel";
-		this.build(message);
+		this.build(message, detail);
 	}
 
 	close(): void {
@@ -89,7 +89,7 @@ export class ConfirmDialog {
 		}
 	}
 
-	private build(message: string): void {
+	private build(message: string, detail: string): void {
 		const theme = getTheme();
 		const left = Math.max(
 			0,
@@ -127,7 +127,7 @@ export class ConfirmDialog {
 		);
 		container.add(
 			new TextRenderable(this.renderer, {
-				content: "  Files will be deleted from disk.".padEnd(inner),
+				content: `  ${detail}`.padEnd(inner),
 				fg: theme.fgSecondary,
 			}),
 		);

--- a/src/layout/content-window.ts
+++ b/src/layout/content-window.ts
@@ -41,7 +41,10 @@ export class ContentWindow {
 		const state = this.store.getState();
 		(this.tableFrame as unknown as { borderColor: string }).borderColor =
 			focusArea === "table" ? theme.accent : theme.border;
-		const visible = filterTorrents(state.torrents, state.selectedView);
+		const visible = filterTorrents(state.torrents, {
+			view: state.selectedView,
+			searchQuery: state.searchQuery,
+		});
 		this.torrentTable.update(visible, selectedIndex, focusArea);
 		const selectedTorrent =
 			focusArea === "sidebar" ? null : (visible[selectedIndex] ?? null);

--- a/src/layout/directory-picker-dialog.ts
+++ b/src/layout/directory-picker-dialog.ts
@@ -1,6 +1,14 @@
 import { existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, isAbsolute, join, normalize, relative } from "node:path";
+import {
+	basename,
+	dirname,
+	isAbsolute,
+	join,
+	normalize,
+	resolve,
+	sep,
+} from "node:path";
 import {
 	BoxRenderable,
 	type CliRenderer,
@@ -167,8 +175,23 @@ export class DirectoryPickerDialog {
 		}
 		if (key.name === "return" || key.name === "enter") {
 			const name = this.folderName.trim();
-			if (name.length > 0 && !name.includes("/")) {
+			if (name.length > 0) {
+				if (!isSafeFolderName(name)) {
+					this.errorMessage = "Folder name cannot include path segments";
+					this.render();
+					return true;
+				}
 				const nextPath = join(this.currentPath, name);
+				const resolvedNext = resolve(nextPath);
+				const rootResolved = resolve(ROOT_DIRECTORY);
+				if (
+					resolvedNext !== rootResolved &&
+					!resolvedNext.startsWith(rootResolved + sep)
+				) {
+					this.errorMessage = "Folder must stay inside your home directory";
+					this.render();
+					return true;
+				}
 				try {
 					mkdirSync(nextPath, { recursive: true });
 					this.creatingFolder = false;
@@ -237,10 +260,11 @@ export class DirectoryPickerDialog {
 			setText(this.pathText, truncateMiddle(this.currentPath, pathWidth));
 		}
 		if (this.hintText) {
-			const content = this.creatingFolder
-				? `New folder: ${this.folderName}█`
-				: this.errorMessage ||
-					"Enter open  Space choose  Backspace parent  n new  Esc cancel";
+			const content =
+				this.errorMessage ||
+				(this.creatingFolder
+					? `New folder: ${this.folderName}█`
+					: "Enter open  Space choose  Backspace parent  n new  Esc cancel");
 			setText(this.hintText, truncateMiddle(content, pathWidth));
 			setFg(this.hintText, this.errorMessage ? theme.error : theme.fgMuted);
 		}
@@ -256,9 +280,7 @@ export class DirectoryPickerDialog {
 			}
 			const selected = this.scrollOffset + i === this.cursor;
 			const parent = entry === dirname(this.currentPath);
-			const name = parent
-				? ".."
-				: (entry.split("/").filter(Boolean).pop() ?? entry);
+			const name = parent ? ".." : basename(entry);
 			setText(
 				row.text,
 				`${" ".repeat(MARGIN)}${truncateMiddle(name, pathWidth)}`,
@@ -360,7 +382,7 @@ export class DirectoryPickerDialog {
 function nearestExistingDirectory(path: string): string {
 	let current = normalize(path || ROOT_DIRECTORY);
 	if (!isWithinRoot(current)) return ROOT_DIRECTORY;
-	while (!existsSync(current) || !statSync(current).isDirectory()) {
+	while (!existsSync(current) || !isDirectorySafe(current)) {
 		const parent = dirname(current);
 		if (parent === current || !isWithinRoot(parent)) return ROOT_DIRECTORY;
 		current = parent;
@@ -368,10 +390,26 @@ function nearestExistingDirectory(path: string): string {
 	return current;
 }
 
+function isDirectorySafe(path: string): boolean {
+	try {
+		return statSync(path).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
 function isWithinRoot(path: string): boolean {
 	const normalized = normalize(path);
-	const rel = relative(ROOT_DIRECTORY, normalized);
-	return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+	const root = resolve(ROOT_DIRECTORY);
+	const target = resolve(normalized);
+	return target === root || target.startsWith(root + sep);
+}
+
+function isSafeFolderName(name: string): boolean {
+	if (isAbsolute(name)) return false;
+	if (/^[a-zA-Z]:/.test(name)) return false;
+	if (name.includes("/") || name.includes("\\")) return false;
+	return !name.split(/[\\/]+/).some((part) => part === ".." || part === "");
 }
 
 function charFromKey(key: KeyEvent): string {

--- a/src/layout/directory-picker-dialog.ts
+++ b/src/layout/directory-picker-dialog.ts
@@ -1,0 +1,383 @@
+import { existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, normalize, relative } from "node:path";
+import {
+	BoxRenderable,
+	type CliRenderer,
+	type KeyEvent,
+	TextRenderable,
+} from "@opentui/core";
+import { getTheme } from "../theme";
+import type { LayoutDimensions } from "../types/layout";
+import { resolvePath } from "../utils/paths";
+
+const DIALOG_WIDTH = 68;
+const DIALOG_HEIGHT = 22;
+const INNER_W = DIALOG_WIDTH - 2;
+const MARGIN = 2;
+const LIST_ROWS = 13;
+const ROOT_DIRECTORY = normalize(homedir());
+
+interface DirectoryRow {
+	container: BoxRenderable;
+	text: TextRenderable;
+}
+
+function truncateMiddle(text: string, max: number): string {
+	if (text.length <= max) return text;
+	if (max <= 1) return "…";
+	const left = Math.floor((max - 1) / 2);
+	const right = max - 1 - left;
+	return `${text.slice(0, left)}…${text.slice(-right)}`;
+}
+
+function setText(node: TextRenderable, content: string): void {
+	(node as unknown as { content: string }).content = content;
+}
+
+function setFg(node: TextRenderable, fg: string): void {
+	(node as unknown as { fg: string }).fg = fg;
+}
+
+function setBg(node: BoxRenderable, bg: string | undefined): void {
+	(node as unknown as { backgroundColor: string | undefined }).backgroundColor =
+		bg;
+}
+
+export class DirectoryPickerDialog {
+	private renderer: CliRenderer;
+	private layout: LayoutDimensions;
+	private container: BoxRenderable | null = null;
+	private titleText: TextRenderable | null = null;
+	private pathText: TextRenderable | null = null;
+	private hintText: TextRenderable | null = null;
+	private rows: DirectoryRow[] = [];
+	private isOpen = false;
+	private currentPath = "";
+	private entries: string[] = [];
+	private cursor = 0;
+	private scrollOffset = 0;
+	private creatingFolder = false;
+	private folderName = "";
+	private errorMessage = "";
+
+	onCancel?: () => void;
+	onSelect?: (path: string) => void;
+
+	constructor(renderer: CliRenderer, layout: LayoutDimensions) {
+		this.renderer = renderer;
+		this.layout = layout;
+		this.createElements();
+	}
+
+	open(initialPath: string, title = "Choose directory"): void {
+		this.isOpen = true;
+		this.creatingFolder = false;
+		this.folderName = "";
+		this.errorMessage = "";
+		this.currentPath = nearestExistingDirectory(resolvePath(initialPath));
+		this.cursor = 0;
+		this.scrollOffset = 0;
+		if (this.titleText) setText(this.titleText, title);
+		this.refreshEntries();
+		this.updatePosition();
+		this.render();
+		if (this.container) this.container.visible = true;
+	}
+
+	close(): void {
+		if (!this.isOpen) return;
+		this.isOpen = false;
+		this.creatingFolder = false;
+		this.folderName = "";
+		if (this.container) this.container.visible = false;
+	}
+
+	getIsOpen(): boolean {
+		return this.isOpen;
+	}
+
+	handleInput(key: KeyEvent): boolean {
+		if (!this.isOpen) return false;
+		if (this.creatingFolder) return this.handleFolderNameInput(key);
+
+		if (key.name === "escape") {
+			this.close();
+			this.onCancel?.();
+			return true;
+		}
+		if (key.name === "space") {
+			const selected = this.currentPath;
+			this.close();
+			this.onSelect?.(selected);
+			return true;
+		}
+		if (key.name === "backspace" || key.name === "left") {
+			if (this.currentPath !== ROOT_DIRECTORY) {
+				this.openPath(dirname(this.currentPath));
+			}
+			return true;
+		}
+		if (key.name === "n") {
+			this.creatingFolder = true;
+			this.folderName = "";
+			this.render();
+			return true;
+		}
+		if (key.name === "j" || key.name === "down") {
+			if (this.cursor < this.entries.length - 1) {
+				this.cursor++;
+				this.ensureCursorVisible();
+				this.render();
+			}
+			return true;
+		}
+		if (key.name === "k" || key.name === "up") {
+			if (this.cursor > 0) {
+				this.cursor--;
+				this.ensureCursorVisible();
+				this.render();
+			}
+			return true;
+		}
+		if (key.name === "return" || key.name === "enter") {
+			const next = this.entries[this.cursor];
+			if (next) this.openPath(next);
+			return true;
+		}
+		return false;
+	}
+
+	updateLayout(layout: LayoutDimensions): void {
+		this.layout = layout;
+		if (this.isOpen) this.updatePosition();
+	}
+
+	private handleFolderNameInput(key: KeyEvent): boolean {
+		if (key.name === "escape") {
+			this.creatingFolder = false;
+			this.folderName = "";
+			this.render();
+			return true;
+		}
+		if (key.name === "backspace") {
+			this.folderName = this.folderName.slice(0, -1);
+			this.render();
+			return true;
+		}
+		if (key.name === "return" || key.name === "enter") {
+			const name = this.folderName.trim();
+			if (name.length > 0 && !name.includes("/")) {
+				const nextPath = join(this.currentPath, name);
+				try {
+					mkdirSync(nextPath, { recursive: true });
+					this.creatingFolder = false;
+					this.folderName = "";
+					this.openPath(nextPath);
+				} catch (err) {
+					this.errorMessage = err instanceof Error ? err.message : String(err);
+					this.render();
+				}
+			}
+			return true;
+		}
+		const char = charFromKey(key);
+		if (char) {
+			this.folderName += char;
+			this.render();
+		}
+		return true;
+	}
+
+	private openPath(path: string): void {
+		this.currentPath = nearestExistingDirectory(path);
+		this.cursor = 0;
+		this.scrollOffset = 0;
+		this.refreshEntries();
+		this.render();
+	}
+
+	private refreshEntries(): void {
+		this.errorMessage = "";
+		try {
+			const children = readdirSync(this.currentPath)
+				.map((name) => join(this.currentPath, name))
+				.filter((path) => {
+					try {
+						return statSync(path).isDirectory();
+					} catch {
+						return false;
+					}
+				})
+				.sort((a, b) => a.localeCompare(b));
+			const parent = dirname(this.currentPath);
+			this.entries =
+				this.currentPath === ROOT_DIRECTORY || parent === this.currentPath
+					? children
+					: [parent, ...children];
+		} catch (err) {
+			this.entries =
+				this.currentPath === ROOT_DIRECTORY ? [] : [dirname(this.currentPath)];
+			this.errorMessage = err instanceof Error ? err.message : String(err);
+		}
+	}
+
+	private ensureCursorVisible(): void {
+		if (this.cursor < this.scrollOffset) {
+			this.scrollOffset = this.cursor;
+		} else if (this.cursor >= this.scrollOffset + LIST_ROWS) {
+			this.scrollOffset = this.cursor - LIST_ROWS + 1;
+		}
+	}
+
+	private render(): void {
+		const theme = getTheme();
+		const pathWidth = INNER_W - MARGIN * 2;
+		if (this.pathText) {
+			setText(this.pathText, truncateMiddle(this.currentPath, pathWidth));
+		}
+		if (this.hintText) {
+			const content = this.creatingFolder
+				? `New folder: ${this.folderName}█`
+				: this.errorMessage ||
+					"Enter open  Space choose  Backspace parent  n new  Esc cancel";
+			setText(this.hintText, truncateMiddle(content, pathWidth));
+			setFg(this.hintText, this.errorMessage ? theme.error : theme.fgMuted);
+		}
+
+		for (let i = 0; i < this.rows.length; i++) {
+			const row = this.rows[i];
+			const entry = this.entries[this.scrollOffset + i];
+			if (!row) continue;
+			if (!entry) {
+				setText(row.text, "");
+				setBg(row.container, undefined);
+				continue;
+			}
+			const selected = this.scrollOffset + i === this.cursor;
+			const parent = entry === dirname(this.currentPath);
+			const name = parent
+				? ".."
+				: (entry.split("/").filter(Boolean).pop() ?? entry);
+			setText(
+				row.text,
+				`${" ".repeat(MARGIN)}${truncateMiddle(name, pathWidth)}`,
+			);
+			setFg(row.text, selected ? theme.fgPrimary : theme.fgSecondary);
+			setBg(row.container, selected ? theme.bgTertiary : undefined);
+		}
+	}
+
+	private updatePosition(): void {
+		if (!this.container) return;
+		this.container.left = Math.max(
+			0,
+			Math.floor((this.layout.terminal.width - DIALOG_WIDTH) / 2),
+		);
+		this.container.top = Math.max(
+			0,
+			Math.floor((this.layout.terminal.height - DIALOG_HEIGHT) / 2),
+		);
+	}
+
+	private createElements(): void {
+		const theme = getTheme();
+		const container = new BoxRenderable(this.renderer, {
+			position: "absolute",
+			left: 0,
+			top: 0,
+			width: DIALOG_WIDTH,
+			height: DIALOG_HEIGHT,
+			border: true,
+			borderStyle: "single",
+			borderColor: theme.accent,
+			backgroundColor: theme.bgPrimary,
+			visible: false,
+			flexDirection: "column",
+		});
+
+		const titleRow = new BoxRenderable(this.renderer, {
+			width: INNER_W,
+			height: 1,
+			paddingLeft: MARGIN,
+			paddingRight: MARGIN,
+		});
+		this.titleText = new TextRenderable(this.renderer, {
+			content: "Choose directory",
+			fg: theme.accent,
+		});
+		titleRow.add(this.titleText);
+		container.add(titleRow);
+
+		const pathRow = new BoxRenderable(this.renderer, {
+			width: INNER_W,
+			height: 1,
+			paddingLeft: MARGIN,
+			paddingRight: MARGIN,
+			marginTop: 1,
+		});
+		this.pathText = new TextRenderable(this.renderer, {
+			content: "",
+			fg: theme.fgPrimary,
+		});
+		pathRow.add(this.pathText);
+		container.add(pathRow);
+
+		container.add(new BoxRenderable(this.renderer, { height: 1 }));
+		for (let i = 0; i < LIST_ROWS; i++) {
+			const rowContainer = new BoxRenderable(this.renderer, {
+				width: INNER_W,
+				height: 1,
+			});
+			const text = new TextRenderable(this.renderer, {
+				content: "",
+				fg: theme.fgSecondary,
+			});
+			rowContainer.add(text);
+			container.add(rowContainer);
+			this.rows.push({ container: rowContainer, text });
+		}
+
+		container.add(new BoxRenderable(this.renderer, { flexGrow: 1 }));
+		const hintRow = new BoxRenderable(this.renderer, {
+			width: INNER_W,
+			height: 1,
+			paddingLeft: MARGIN,
+			paddingRight: MARGIN,
+		});
+		this.hintText = new TextRenderable(this.renderer, {
+			content: "",
+			fg: theme.fgMuted,
+		});
+		hintRow.add(this.hintText);
+		container.add(hintRow);
+
+		this.renderer.root.add(container);
+		this.container = container;
+	}
+}
+
+function nearestExistingDirectory(path: string): string {
+	let current = normalize(path || ROOT_DIRECTORY);
+	if (!isWithinRoot(current)) return ROOT_DIRECTORY;
+	while (!existsSync(current) || !statSync(current).isDirectory()) {
+		const parent = dirname(current);
+		if (parent === current || !isWithinRoot(parent)) return ROOT_DIRECTORY;
+		current = parent;
+	}
+	return current;
+}
+
+function isWithinRoot(path: string): boolean {
+	const normalized = normalize(path);
+	const rel = relative(ROOT_DIRECTORY, normalized);
+	return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function charFromKey(key: KeyEvent): string {
+	if (key.ctrl || key.meta) return "";
+	if (key.name === "space") return " ";
+	if (key.name.length !== 1) return "";
+	if (key.shift && /^[a-z]$/.test(key.name)) return key.name.toUpperCase();
+	return key.name;
+}

--- a/src/layout/sidebar.ts
+++ b/src/layout/sidebar.ts
@@ -23,7 +23,6 @@ export class Sidebar {
 	private titleText: TextRenderable | null = null;
 	private headingRows: BoxRenderable[] = [];
 	private itemTexts: SidebarItem[] = [];
-	private rowCount = 0;
 	private layout: LayoutDimensions;
 
 	constructor(renderer: CliRenderer, store: Store, layout: LayoutDimensions) {
@@ -39,7 +38,6 @@ export class Sidebar {
 		const theme = getTheme();
 		const sidebarActive = focusArea === "sidebar";
 		const items = buildSidebarSelectableItems();
-		if (items.length !== this.rowCount) this.rebuildItems();
 
 		(this.container as unknown as { borderColor: string }).borderColor =
 			sidebarActive ? theme.accent : theme.border;
@@ -59,9 +57,11 @@ export class Sidebar {
 
 	updateLayout(layout: LayoutDimensions): void {
 		this.layout = layout;
+		this.container.left = layout.sidebar.x;
+		this.container.top = layout.sidebar.y;
 		this.container.width = layout.sidebar.width;
 		this.container.height = layout.sidebar.height;
-		this.rebuildItems();
+		this.positionRows();
 	}
 
 	private build(): BoxRenderable {
@@ -98,16 +98,13 @@ export class Sidebar {
 	}
 
 	private rebuildItems(): void {
-		for (const heading of this.headingRows) heading.destroy();
-		for (const item of this.itemTexts) item.container.destroy();
 		this.headingRows = [];
 		this.itemTexts = [];
 		const theme = getTheme();
-		let yOffset = 3;
 		const statusTitle = new BoxRenderable(this.renderer, {
 			position: "absolute",
 			left: 1,
-			top: yOffset,
+			top: 3,
 		});
 		const statusTitleText = new TextRenderable(this.renderer, {
 			content: "Status",
@@ -116,28 +113,40 @@ export class Sidebar {
 		statusTitle.add(statusTitleText);
 		this.container.add(statusTitle);
 		this.headingRows.push(statusTitle);
-		yOffset += 2;
 
-		for (let i = 0; i < SIDEBAR_ITEMS.status.length; i++) {
-			const item = SIDEBAR_ITEMS.status[i];
+		const items = buildSidebarSelectableItems();
+		for (let i = 0; i < items.length; i++) {
+			const item = items[i];
 			if (!item) continue;
 			const isSelected = i === this.store.getState().selectedIndex;
 			const itemBox = new BoxRenderable(this.renderer, {
 				position: "absolute",
 				left: 1,
-				top: yOffset,
+				top: 5 + i,
 				width: this.layout.sidebar.width - 2,
 			});
 			const text = new TextRenderable(this.renderer, {
-				content: `${isSelected ? "> " : "  "}${item}`,
+				content: `${isSelected ? "> " : "  "}${item.label}`,
 				fg: isSelected ? theme.accent : theme.fgPrimary,
 			});
 			itemBox.add(text);
 			this.container.add(itemBox);
 			this.itemTexts.push({ container: itemBox, text, globalIndex: i });
-			yOffset += 1;
 		}
-		this.rowCount = buildSidebarSelectableItems().length;
+	}
+
+	private positionRows(): void {
+		for (const heading of this.headingRows) {
+			heading.left = 1;
+			heading.width = this.layout.sidebar.width - 2;
+		}
+		for (let i = 0; i < this.itemTexts.length; i++) {
+			const item = this.itemTexts[i];
+			if (!item) continue;
+			item.container.left = 1;
+			item.container.top = 5 + i;
+			item.container.width = this.layout.sidebar.width - 2;
+		}
 	}
 }
 

--- a/src/layout/sidebar.ts
+++ b/src/layout/sidebar.ts
@@ -20,6 +20,7 @@ export class Sidebar {
 	private renderer: CliRenderer;
 	private store: Store;
 	private container: BoxRenderable;
+	private titleBox: BoxRenderable | null = null;
 	private titleText: TextRenderable | null = null;
 	private headingRows: BoxRenderable[] = [];
 	private itemTexts: SidebarItem[] = [];
@@ -61,6 +62,11 @@ export class Sidebar {
 		this.container.top = layout.sidebar.y;
 		this.container.width = layout.sidebar.width;
 		this.container.height = layout.sidebar.height;
+		if (this.titleBox) {
+			this.titleBox.left = 0;
+			this.titleBox.top = 0;
+			this.titleBox.width = layout.sidebar.width;
+		}
 		this.positionRows();
 	}
 
@@ -76,7 +82,7 @@ export class Sidebar {
 			borderColor: theme.border,
 		});
 
-		const titleBox = new BoxRenderable(this.renderer, {
+		this.titleBox = new BoxRenderable(this.renderer, {
 			position: "absolute",
 			left: 0,
 			top: 0,
@@ -89,8 +95,8 @@ export class Sidebar {
 			content: APP_NAME,
 			fg: theme.accent,
 		});
-		titleBox.add(this.titleText);
-		this.container.add(titleBox);
+		this.titleBox.add(this.titleText);
+		this.container.add(this.titleBox);
 
 		this.rebuildItems();
 

--- a/src/layout/sidebar.ts
+++ b/src/layout/sidebar.ts
@@ -6,8 +6,14 @@ import type { LayoutDimensions } from "../types/layout";
 import type { FocusArea } from "./content-window";
 
 interface SidebarItem {
+	container: BoxRenderable;
 	text: TextRenderable;
 	globalIndex: number;
+}
+
+export interface SidebarSelectableItem {
+	label: string;
+	selectedView: string;
 }
 
 export class Sidebar {
@@ -15,7 +21,9 @@ export class Sidebar {
 	private store: Store;
 	private container: BoxRenderable;
 	private titleText: TextRenderable | null = null;
+	private headingRows: BoxRenderable[] = [];
 	private itemTexts: SidebarItem[] = [];
+	private rowCount = 0;
 	private layout: LayoutDimensions;
 
 	constructor(renderer: CliRenderer, store: Store, layout: LayoutDimensions) {
@@ -30,12 +38,14 @@ export class Sidebar {
 		const s = state ?? this.store.getState();
 		const theme = getTheme();
 		const sidebarActive = focusArea === "sidebar";
+		const items = buildSidebarSelectableItems();
+		if (items.length !== this.rowCount) this.rebuildItems();
 
 		(this.container as unknown as { borderColor: string }).borderColor =
 			sidebarActive ? theme.accent : theme.border;
 
 		for (const item of this.itemTexts) {
-			const itemName = SIDEBAR_ITEMS.status[item.globalIndex] ?? "";
+			const itemName = items[item.globalIndex]?.label ?? "";
 			const isSelected = item.globalIndex === s.selectedIndex;
 			(item.text as unknown as { content: string }).content =
 				`${isSelected && sidebarActive ? "> " : "  "}${itemName}`;
@@ -51,12 +61,11 @@ export class Sidebar {
 		this.layout = layout;
 		this.container.width = layout.sidebar.width;
 		this.container.height = layout.sidebar.height;
+		this.rebuildItems();
 	}
 
 	private build(): BoxRenderable {
 		const theme = getTheme();
-		const state = this.store.getState();
-
 		this.container = new BoxRenderable(this.renderer, {
 			position: "absolute",
 			left: this.layout.sidebar.x,
@@ -83,8 +92,18 @@ export class Sidebar {
 		titleBox.add(this.titleText);
 		this.container.add(titleBox);
 
-		let yOffset = 3;
+		this.rebuildItems();
 
+		return this.container;
+	}
+
+	private rebuildItems(): void {
+		for (const heading of this.headingRows) heading.destroy();
+		for (const item of this.itemTexts) item.container.destroy();
+		this.headingRows = [];
+		this.itemTexts = [];
+		const theme = getTheme();
+		let yOffset = 3;
 		const statusTitle = new BoxRenderable(this.renderer, {
 			position: "absolute",
 			left: 1,
@@ -96,29 +115,35 @@ export class Sidebar {
 		});
 		statusTitle.add(statusTitleText);
 		this.container.add(statusTitle);
+		this.headingRows.push(statusTitle);
 		yOffset += 2;
 
 		for (let i = 0; i < SIDEBAR_ITEMS.status.length; i++) {
-			const isSelected = i === state.selectedIndex;
-			const itemName = SIDEBAR_ITEMS.status[i];
-
+			const item = SIDEBAR_ITEMS.status[i];
+			if (!item) continue;
+			const isSelected = i === this.store.getState().selectedIndex;
 			const itemBox = new BoxRenderable(this.renderer, {
 				position: "absolute",
 				left: 1,
 				top: yOffset,
+				width: this.layout.sidebar.width - 2,
 			});
-
 			const text = new TextRenderable(this.renderer, {
-				content: `${isSelected ? "> " : "  "}${itemName}`,
+				content: `${isSelected ? "> " : "  "}${item}`,
 				fg: isSelected ? theme.accent : theme.fgPrimary,
 			});
-
 			itemBox.add(text);
 			this.container.add(itemBox);
-			this.itemTexts.push({ text, globalIndex: i });
+			this.itemTexts.push({ container: itemBox, text, globalIndex: i });
 			yOffset += 1;
 		}
-
-		return this.container;
+		this.rowCount = buildSidebarSelectableItems().length;
 	}
+}
+
+export function buildSidebarSelectableItems(): SidebarSelectableItem[] {
+	return SIDEBAR_ITEMS.status.map((status) => ({
+		label: status,
+		selectedView: status,
+	}));
 }

--- a/src/layout/status-bar.ts
+++ b/src/layout/status-bar.ts
@@ -27,8 +27,22 @@ export class StatusBar {
 		this.renderer.root.add(this.container);
 	}
 
-	update(state: AppState, focusArea: FocusArea = "sidebar"): void {
+	update(
+		state: AppState,
+		focusArea: FocusArea = "sidebar",
+		searchActive = false,
+	): void {
 		const theme = getTheme();
+		if (searchActive || state.searchQuery.length > 0) {
+			(this.leftText as unknown as { content: string }).content =
+				` / ${state.searchQuery}${searchActive ? "█" : ""}`;
+			(this.leftText as unknown as { fg: string }).fg = theme.accent;
+			(this.rightText as unknown as { content: string }).content = searchActive
+				? "type search  Enter keep  Esc clear "
+				: this.hintsFor(focusArea);
+			(this.rightText as unknown as { fg: string }).fg = theme.fgMuted;
+			return;
+		}
 		const dl = formatSpeed(state.totalDownloadBps);
 		const ul = formatSpeed(state.totalUploadBps);
 		const count = state.torrents.length;
@@ -87,9 +101,9 @@ export class StatusBar {
 	private hintsFor(focusArea: FocusArea): string {
 		switch (focusArea) {
 			case "sidebar":
-				return "j/k nav  Tab focus  a add  q quit ";
+				return "j/k nav  m manage  Tab focus  a add  q quit ";
 			case "table":
-				return "j/k select  Space action  d del  D del+files  Tab focus ";
+				return "j/k select  / search  c category  Space action  d del ";
 			case "details":
 				return "h/l tabs  j/k scroll  Tab focus  q quit ";
 		}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -27,9 +27,18 @@ export interface TorrentPeerState {
 	uploadBps: number;
 }
 
+export interface CategoryState {
+	id: string;
+	name: string;
+	savePath: string | null;
+}
+
 export interface TorrentState {
 	id: string;
 	name: string;
+	categoryId: string | null;
+	categoryName: string | null;
+	savePath: string;
 	targetPath: string;
 	totalSize: number;
 	pieceLength: number;
@@ -49,6 +58,8 @@ export interface TorrentState {
 export interface AppState {
 	selectedIndex: number;
 	selectedView: string;
+	searchQuery: string;
+	categories: CategoryState[];
 	torrents: TorrentState[];
 	totalDownloadBps: number;
 	totalUploadBps: number;
@@ -60,8 +71,15 @@ export class Store {
 	private state: AppState;
 	private listeners: Set<Listener> = new Set();
 
-	constructor(initial: AppState) {
-		this.state = { ...initial };
+	constructor(
+		initial: Omit<AppState, "categories" | "searchQuery"> &
+			Partial<Pick<AppState, "categories" | "searchQuery">>,
+	) {
+		this.state = {
+			...initial,
+			categories: initial.categories ?? [],
+			searchQuery: initial.searchQuery ?? "",
+		};
 	}
 
 	getState(): AppState {

--- a/src/torrent/bridge.ts
+++ b/src/torrent/bridge.ts
@@ -36,6 +36,9 @@ import {
 interface TorrentEntry {
 	torrentPath: string;
 	magnetUri?: string;
+	savePath: string;
+	categoryId: string | null;
+	categoryName: string | null;
 	session: TorrentSession | null;
 	manager: PeerManager | null;
 	trackerCoordinator: DiscoveryCoordinator | null;
@@ -55,6 +58,9 @@ interface SessionRegistry {
 		infoHash: string;
 		torrentPath: string;
 		magnetUri?: string;
+		savePath?: string;
+		categoryId?: string | null;
+		categoryName?: string | null;
 	}>;
 }
 
@@ -63,6 +69,7 @@ interface RestoreCheckJob {
 	id: string;
 	metadata: TorrentMetadata;
 	onProgress?: (progress: RestoreProgress) => void;
+	savePath: string;
 	total: number;
 }
 
@@ -79,6 +86,22 @@ export interface AddTorrentResult {
 	id: string;
 	name: string;
 	added: boolean;
+}
+
+export interface PreparedTorrentAdd extends AddTorrentResult {
+	files: TorrentState["files"];
+	isMultiFile: boolean;
+	magnetUri?: string;
+	pieceLength: number;
+	torrentPath: string;
+	totalPieces: number;
+	totalSize: number;
+}
+
+export interface ConfirmTorrentAddOptions {
+	categoryId: string | null;
+	categoryName: string | null;
+	savePath: string;
 }
 
 export class TorrentBridge {
@@ -117,7 +140,11 @@ export class TorrentBridge {
 		let current = 0;
 		this.restoreCheckQueue = [];
 
-		for (const { infoHash, torrentPath, magnetUri } of registry.torrents) {
+		for (const restored of registry.torrents) {
+			const { infoHash, torrentPath, magnetUri } = restored;
+			const savePath = resolvePath(restored.savePath ?? this.downloadPath);
+			const categoryId = restored.categoryId ?? null;
+			const categoryName = restored.categoryName ?? null;
 			current++;
 			if (!torrentPath || !existsSync(torrentPath)) {
 				if (!magnetUri) continue;
@@ -126,6 +153,9 @@ export class TorrentBridge {
 					const entry: TorrentEntry = {
 						torrentPath: "",
 						magnetUri,
+						savePath,
+						categoryId,
+						categoryName,
 						session: null,
 						manager: null,
 						trackerCoordinator: null,
@@ -139,7 +169,10 @@ export class TorrentBridge {
 						state: {
 							id: infoHash,
 							name: magnet.displayName ?? `magnet:${infoHash.slice(0, 12)}`,
-							targetPath: this.downloadPath,
+							categoryId,
+							categoryName,
+							savePath,
+							targetPath: savePath,
 							totalSize: 0,
 							pieceLength: 0,
 							downloadedPieces: 0,
@@ -166,10 +199,7 @@ export class TorrentBridge {
 				const actualId = Buffer.from(metadata.infoHash).toString("hex");
 				if (actualId !== infoHash) continue;
 
-				const trustedResume = loadTrustedResumeData(
-					metadata,
-					this.downloadPath,
-				);
+				const trustedResume = loadTrustedResumeData(metadata, savePath);
 				const downloadedPieces = trustedResume?.verifiedPieces.length ?? 0;
 				const resumeComplete = downloadedPieces >= metadata.pieceCount;
 
@@ -210,10 +240,16 @@ export class TorrentBridge {
 					checkingPromise: null,
 					selectedFileIndices: restoredSelection,
 					fileDownloadedBytes: metadata.files.map(() => 0),
+					savePath,
+					categoryId,
+					categoryName,
 					state: {
 						id: infoHash,
 						name: metadata.name,
-						targetPath: this.targetPathFor(metadata),
+						categoryId,
+						categoryName,
+						savePath,
+						targetPath: this.targetPathFor(metadata, savePath),
 						totalSize: metadata.totalSize,
 						pieceLength: metadata.pieceLength,
 						downloadedPieces,
@@ -237,6 +273,7 @@ export class TorrentBridge {
 						id: infoHash,
 						metadata,
 						onProgress,
+						savePath,
 						total,
 					});
 				} else {
@@ -310,7 +347,7 @@ export class TorrentBridge {
 		job: RestoreCheckJob,
 		controller: AbortController,
 	): Promise<void> {
-		const storage = new StorageManager(job.metadata, this.downloadPath);
+		const storage = new StorageManager(job.metadata, job.savePath);
 		try {
 			const resumeData = readResumeData(job.id);
 			const resumeCount =
@@ -339,7 +376,7 @@ export class TorrentBridge {
 			if (summary.corrupt === 0) {
 				writeResumeData(
 					job.metadata,
-					this.downloadPath,
+					job.savePath,
 					storage.getDownloadedPieces(),
 				);
 			}
@@ -386,129 +423,111 @@ export class TorrentBridge {
 		}
 	}
 
+	async prepareAdd(input: string): Promise<PreparedTorrentAdd> {
+		return parseMagnetUriSafe(input)
+			? this.prepareMagnet(input)
+			: this.prepareTorrent(input);
+	}
+
+	async confirmAdd(
+		prepared: PreparedTorrentAdd,
+		options: ConfirmTorrentAddOptions,
+	): Promise<AddTorrentResult> {
+		if (this.torrents.has(prepared.id)) {
+			return { id: prepared.id, name: prepared.name, added: false };
+		}
+		const savePath = resolvePath(options.savePath);
+		const metadata = this.parseTorrent(prepared.torrentPath);
+		const entry = this.createQueuedEntry({
+			categoryId: options.categoryId,
+			categoryName: options.categoryName,
+			id: prepared.id,
+			magnetUri: prepared.magnetUri,
+			metadata,
+			savePath,
+			torrentPath: prepared.torrentPath,
+		});
+		this.torrents.set(prepared.id, entry);
+		this.saveRegistry();
+		this.flushAll();
+		return { id: prepared.id, name: prepared.name, added: true };
+	}
+
 	async addTorrent(torrentPath: string): Promise<AddTorrentResult> {
+		const prepared = await this.prepareTorrent(torrentPath);
+		if (!prepared.added)
+			return { id: prepared.id, name: prepared.name, added: false };
+		return this.confirmAdd(prepared, {
+			categoryId: null,
+			categoryName: null,
+			savePath: this.downloadPath,
+		});
+	}
+
+	private async prepareTorrent(
+		torrentPath: string,
+	): Promise<PreparedTorrentAdd> {
 		const metadata = this.parseTorrent(torrentPath);
 		const id = Buffer.from(metadata.infoHash).toString("hex");
 
-		if (this.torrents.has(id)) return { id, name: metadata.name, added: false };
-
-		const entry: TorrentEntry = {
+		return {
+			id,
+			name: metadata.name,
+			added: !this.torrents.has(id),
+			files: buildFileStates(metadata.files, null),
+			isMultiFile: metadata.files.length > 1,
+			pieceLength: metadata.pieceLength,
 			torrentPath,
-			session: null,
-			manager: null,
-			trackerCoordinator: null,
-			downloader: null,
-			hasTransferActivity: false,
-			uploadedAccumulator: createUploadedAccumulator(),
-			checkingAbort: null,
-			checkingPromise: null,
-			selectedFileIndices: null,
-			fileDownloadedBytes: metadata.files.map(() => 0),
-			state: {
-				id,
-				name: metadata.name,
-				targetPath: this.targetPathFor(metadata),
-				totalSize: metadata.totalSize,
-				pieceLength: metadata.pieceLength,
-				downloadedPieces: 0,
-				totalPieces: metadata.pieceCount,
-				status: "queued",
-				downloadBps: 0,
-				uploadBps: 0,
-				peers: 0,
-				seeds: 0,
-				leechers: 0,
-				peerDetails: [],
-				files: buildFileStates(metadata.files, null),
-				etaSeconds: null,
-			},
+			totalPieces: metadata.pieceCount,
+			totalSize: metadata.totalSize,
 		};
-		this.torrents.set(id, entry);
-		this.saveRegistry();
-		this.flushAll();
-
-		return { id, name: metadata.name, added: true };
 	}
 
 	async addMagnet(uri: string): Promise<AddTorrentResult> {
+		const prepared = await this.prepareMagnet(uri);
+		if (!prepared.added)
+			return { id: prepared.id, name: prepared.name, added: false };
+		return this.confirmAdd(prepared, {
+			categoryId: null,
+			categoryName: null,
+			savePath: this.downloadPath,
+		});
+	}
+
+	private async prepareMagnet(uri: string): Promise<PreparedTorrentAdd> {
 		const magnet = parseMagnetUri(uri);
 		const id = magnet.infoHashHex;
 		const name = magnet.displayName ?? `magnet:${id.slice(0, 12)}`;
 
-		if (this.torrents.has(id)) return { id, name, added: false };
-
-		const entry: TorrentEntry = {
-			torrentPath: "",
-			magnetUri: uri,
-			session: null,
-			manager: null,
-			trackerCoordinator: null,
-			downloader: null,
-			hasTransferActivity: false,
-			uploadedAccumulator: createUploadedAccumulator(),
-			checkingAbort: null,
-			checkingPromise: null,
-			selectedFileIndices: null,
-			fileDownloadedBytes: [],
-			state: {
+		if (this.torrents.has(id)) {
+			return {
 				id,
 				name,
-				targetPath: this.downloadPath,
-				totalSize: 0,
-				pieceLength: 0,
-				downloadedPieces: 0,
-				totalPieces: 0,
-				status: "metadata",
-				downloadBps: 0,
-				uploadBps: 0,
-				peers: magnet.peers.length,
-				seeds: 0,
-				leechers: 0,
-				peerDetails: [],
+				added: false,
 				files: [],
-				etaSeconds: null,
-			},
-		};
-		this.torrents.set(id, entry);
-		this.flushAll();
-
-		try {
-			const result = await resolveMagnetToTorrent(uri, {
-				onProgress: (progress: MagnetResolveProgress) => {
-					this.updateEntry(id, {
-						status: progress.status,
-						peers: progress.peers,
-					});
-				},
-			});
-			const metadata = this.parseTorrent(result.torrentPath);
-			entry.torrentPath = result.torrentPath;
-			entry.selectedFileIndices = null;
-			entry.fileDownloadedBytes = metadata.files.map(() => 0);
-			entry.state = {
-				...entry.state,
-				name: metadata.name,
-				targetPath: this.targetPathFor(metadata),
-				totalSize: metadata.totalSize,
-				pieceLength: metadata.pieceLength,
-				downloadedPieces: 0,
-				totalPieces: metadata.pieceCount,
-				status: "queued",
-				peers: 0,
-				files: buildFileStates(metadata.files, null),
+				isMultiFile: false,
+				magnetUri: uri,
+				pieceLength: 0,
+				torrentPath: "",
+				totalPieces: 0,
+				totalSize: 0,
 			};
-			this.saveRegistry();
-			this.flushAll();
-			return { id, name: metadata.name, added: true };
-		} catch (err) {
-			this.updateEntry(id, {
-				status: "stalled",
-				downloadBps: 0,
-				uploadBps: 0,
-				etaSeconds: null,
-			});
-			throw err;
 		}
+
+		const result = await resolveMagnetToTorrent(uri);
+		const metadata = this.parseTorrent(result.torrentPath);
+		return {
+			id,
+			name: metadata.name,
+			added: true,
+			files: buildFileStates(metadata.files, null),
+			isMultiFile: metadata.files.length > 1,
+			magnetUri: uri,
+			pieceLength: metadata.pieceLength,
+			torrentPath: result.torrentPath,
+			totalPieces: metadata.pieceCount,
+			totalSize: metadata.totalSize,
+		};
 	}
 
 	async startTorrent(id: string): Promise<void> {
@@ -557,6 +576,57 @@ export class TorrentBridge {
 		this.updateEntry(id, { status: "downloading" });
 	}
 
+	setTorrentCategory(
+		id: string,
+		category: { id: string; name: string } | null,
+	): void {
+		const entry = this.torrents.get(id);
+		if (!entry) return;
+		entry.categoryId = category?.id ?? null;
+		entry.categoryName = category?.name ?? null;
+		entry.state = {
+			...entry.state,
+			categoryId: entry.categoryId,
+			categoryName: entry.categoryName,
+		};
+		this.saveRegistry();
+		this.flushAll();
+	}
+
+	renameCategory(categoryId: string, name: string): void {
+		let changed = false;
+		for (const entry of this.torrents.values()) {
+			if (entry.categoryId !== categoryId) continue;
+			entry.categoryName = name;
+			entry.state = {
+				...entry.state,
+				categoryName: name,
+			};
+			changed = true;
+		}
+		if (!changed) return;
+		this.saveRegistry();
+		this.flushAll();
+	}
+
+	clearCategory(categoryId: string): void {
+		let changed = false;
+		for (const entry of this.torrents.values()) {
+			if (entry.categoryId !== categoryId) continue;
+			entry.categoryId = null;
+			entry.categoryName = null;
+			entry.state = {
+				...entry.state,
+				categoryId: null,
+				categoryName: null,
+			};
+			changed = true;
+		}
+		if (!changed) return;
+		this.saveRegistry();
+		this.flushAll();
+	}
+
 	setFileSelection(id: string, selectedIndices: number[] | null): void {
 		const entry = this.torrents.get(id);
 		if (!entry) return;
@@ -576,14 +646,9 @@ export class TorrentBridge {
 			const resumePieces =
 				downloadedPieces.length > 0
 					? downloadedPieces
-					: (loadTrustedResumeData(metadata, this.downloadPath)
-							?.verifiedPieces ?? []);
-			writeResumeData(
-				metadata,
-				this.downloadPath,
-				resumePieces,
-				selectedIndices,
-			);
+					: (loadTrustedResumeData(metadata, entry.savePath)?.verifiedPieces ??
+						[]);
+			writeResumeData(metadata, entry.savePath, resumePieces, selectedIndices);
 		}
 		this.scheduleFlush();
 	}
@@ -605,7 +670,7 @@ export class TorrentBridge {
 		if (deleteFiles) {
 			try {
 				const metadata = this.parseTorrent(entry.torrentPath);
-				const targetPath = this.targetPathFor(metadata);
+				const targetPath = this.targetPathFor(metadata, entry.savePath);
 				rmSync(targetPath, { recursive: true, force: true });
 			} catch {
 				// ignore deletion errors
@@ -662,7 +727,7 @@ export class TorrentBridge {
 			return;
 		}
 
-		const session = new TorrentSession(metadata, this.downloadPath);
+		const session = new TorrentSession(metadata, entry.savePath);
 		entry.session = session;
 		entry.hasTransferActivity = false;
 		entry.uploadedAccumulator = createUploadedAccumulator();
@@ -956,15 +1021,15 @@ export class TorrentBridge {
 		return join(getDataDir(), "session.json");
 	}
 
-	private targetPathFor(metadata: TorrentMetadata): string {
+	private targetPathFor(metadata: TorrentMetadata, savePath: string): string {
 		if (
 			!metadata.isMultiFile &&
 			metadata.files.length === 1 &&
 			metadata.files[0]
 		) {
-			return join(this.downloadPath, metadata.files[0].path);
+			return join(savePath, metadata.files[0].path);
 		}
-		return join(this.downloadPath, metadata.name);
+		return join(savePath, metadata.name);
 	}
 
 	private saveRegistry(): void {
@@ -974,11 +1039,63 @@ export class TorrentBridge {
 				infoHash,
 				torrentPath: entry.torrentPath,
 				magnetUri: entry.magnetUri,
+				savePath: entry.savePath,
+				categoryId: entry.categoryId,
+				categoryName: entry.categoryName,
 			}));
 		writeJsonAtomic(this.registryPath(), {
-			schemaVersion: 1,
+			schemaVersion: 2,
 			torrents: entries,
 		});
+	}
+
+	private createQueuedEntry(options: {
+		categoryId: string | null;
+		categoryName: string | null;
+		id: string;
+		magnetUri?: string;
+		metadata: TorrentMetadata;
+		savePath: string;
+		torrentPath: string;
+	}): TorrentEntry {
+		return {
+			torrentPath: options.torrentPath,
+			magnetUri: options.magnetUri,
+			savePath: options.savePath,
+			categoryId: options.categoryId,
+			categoryName: options.categoryName,
+			session: null,
+			manager: null,
+			trackerCoordinator: null,
+			downloader: null,
+			hasTransferActivity: false,
+			uploadedAccumulator: createUploadedAccumulator(),
+			checkingAbort: null,
+			checkingPromise: null,
+			selectedFileIndices: null,
+			fileDownloadedBytes: options.metadata.files.map(() => 0),
+			state: {
+				id: options.id,
+				name: options.metadata.name,
+				categoryId: options.categoryId,
+				categoryName: options.categoryName,
+				savePath: options.savePath,
+				targetPath: this.targetPathFor(options.metadata, options.savePath),
+				totalSize: options.metadata.totalSize,
+				pieceLength: options.metadata.pieceLength,
+				downloadedPieces: 0,
+				totalPieces: options.metadata.pieceCount,
+				status: "queued",
+				downloadBps: 0,
+				uploadBps: 0,
+				peers: 0,
+				seeds: 0,
+				leechers: 0,
+				peerDetails: [],
+				files: buildFileStates(options.metadata.files, null),
+				etaSeconds: null,
+			},
+		};
 	}
 
 	private updateEntry(id: string, partial: Partial<TorrentState>): void {
@@ -1073,6 +1190,15 @@ function computeSkippedFromSelection(
 		if (!selectedSet.has(i)) skipped.add(i);
 	}
 	return skipped;
+}
+
+function parseMagnetUriSafe(input: string): boolean {
+	try {
+		parseMagnetUri(input);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 export function deriveRuntimeStatus(

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -9,26 +9,46 @@ const ACTIVE_STATUSES = new Set<TorrentState["status"]>([
 	"stalled",
 ]);
 
+export interface TorrentFilterOptions {
+	searchQuery?: string;
+	view?: string;
+}
+
 export function filterTorrents(
 	torrents: TorrentState[],
-	view: string,
+	viewOrOptions: string | TorrentFilterOptions,
 ): TorrentState[] {
+	const options =
+		typeof viewOrOptions === "string" ? { view: viewOrOptions } : viewOrOptions;
+	const view = options.view ?? "All";
+	const query = (options.searchQuery ?? "").trim().toLowerCase();
+	let result: TorrentState[];
 	switch (view) {
 		case "Downloading":
-			return torrents.filter((t) => ACTIVE_STATUSES.has(t.status));
+			result = torrents.filter((t) => ACTIVE_STATUSES.has(t.status));
+			break;
 		case "Seeding":
 		case "Completed":
-			return torrents.filter((t) => t.status === "seeding");
+			result = torrents.filter((t) => t.status === "seeding");
+			break;
 		case "Paused":
-			return torrents.filter((t) => t.status === "paused");
+			result = torrents.filter((t) => t.status === "paused");
+			break;
 		case "Stopped":
-			return torrents.filter(
+			result = torrents.filter(
 				(t) =>
 					t.status === "stopped" ||
 					t.status === "error" ||
 					t.status === "missing",
 			);
+			break;
 		default:
-			return torrents;
+			result = torrents;
 	}
+
+	if (query.length > 0) {
+		result = result.filter((t) => t.name.toLowerCase().includes(query));
+	}
+
+	return result;
 }

--- a/tests/config/categories.test.ts
+++ b/tests/config/categories.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import {
+	createCategory,
+	normalizeCategorySettings,
+	updateCategory,
+} from "../../src/config/categories.ts";
+import { DEFAULT_SETTINGS, settingsSchema } from "../../src/config/settings.ts";
+
+describe("category settings", () => {
+	test("schema defaults categories and defaultCategoryId", () => {
+		const parsed = settingsSchema.parse({});
+
+		expect(parsed.categories).toEqual([]);
+		expect(parsed.defaultCategoryId).toBeNull();
+	});
+
+	test("creates stable unique category ids", () => {
+		const anime = createCategory([], {
+			name: " Anime ",
+			savePath: "/media/anime",
+		});
+		const duplicate = createCategory([anime], {
+			name: "Anime",
+			savePath: null,
+		});
+
+		expect(anime).toEqual({
+			id: "anime",
+			name: "Anime",
+			savePath: "/media/anime",
+		});
+		expect(duplicate.id).toBe("anime-2");
+		expect(duplicate.name).toBe("Anime 2");
+		expect(duplicate.savePath).toBeNull();
+	});
+
+	test("drops invalid default category references", () => {
+		const normalized = normalizeCategorySettings({
+			...DEFAULT_SETTINGS,
+			categories: [{ id: "anime", name: "Anime", savePath: null }],
+			defaultCategoryId: "missing",
+		});
+
+		expect(normalized.defaultCategoryId).toBeNull();
+	});
+
+	test("updates category name and path while keeping ids stable", () => {
+		const anime = createCategory([], {
+			name: "Anime",
+			savePath: "/anime",
+		});
+		const movies = createCategory([anime], {
+			name: "Movies",
+			savePath: null,
+		});
+
+		const updated = updateCategory([anime, movies], anime.id, {
+			name: "Movies",
+			savePath: "",
+		});
+
+		expect(updated[0]).toEqual({
+			id: "anime",
+			name: "Movies 2",
+			savePath: null,
+		});
+		expect(updated[1]).toEqual(movies);
+	});
+});

--- a/tests/layout/category-manager-dialog.test.ts
+++ b/tests/layout/category-manager-dialog.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import type { KeyEvent } from "@opentui/core";
+import { createTestRenderer } from "@opentui/core/testing";
+import { CategoryManagerDialog } from "../../src/layout/category-manager-dialog.ts";
+import type { CategoryState } from "../../src/store/index.ts";
+import type { LayoutDimensions } from "../../src/types/layout.ts";
+
+const TEST_LAYOUT: LayoutDimensions = {
+	terminal: { width: 80, height: 24 },
+	sidebar: { x: 0, y: 0, width: 20, height: 23 },
+	content: { x: 20, y: 0, width: 60, height: 23 },
+	statusBar: { x: 0, y: 23, width: 80, height: 1 },
+};
+
+const CATEGORIES: CategoryState[] = [
+	{ id: "anime", name: "Anime", savePath: "/anime" },
+	{ id: "linux", name: "Linux ISOs", savePath: null },
+];
+
+describe("CategoryManagerDialog", () => {
+	test("renders category management actions", async () => {
+		const { captureCharFrame, renderer, renderOnce } = await createTestRenderer(
+			{
+				width: 80,
+				height: 24,
+			},
+		);
+		try {
+			const dialog = new CategoryManagerDialog(renderer, TEST_LAYOUT);
+
+			dialog.open([
+				{
+					id: "long",
+					name: "Long Path",
+					savePath: ` ${homedir()}/Downloads/torrents/really/long/category/path `,
+				},
+				...CATEGORIES,
+			]);
+			await renderOnce();
+
+			const frame = captureCharFrame();
+			expect(frame).toContain("Manage categories");
+			expect(frame).toContain("Long Path");
+			expect(frame).not.toContain(homedir());
+			expect(frame).toContain("~/Downloads/torr…ng/category/path");
+			expect(frame).toContain("Anime");
+			expect(frame).toContain("/anime");
+			expect(frame).toContain("Linux ISOs");
+			expect(frame).toContain("Enter/e edit");
+			expect(frame).toContain("d delete");
+		} finally {
+			renderer.destroy();
+		}
+	});
+
+	test("fires new edit and delete callbacks", async () => {
+		const { renderer } = await createTestRenderer({
+			width: 80,
+			height: 24,
+		});
+		try {
+			const dialog = new CategoryManagerDialog(renderer, TEST_LAYOUT);
+			let newCount = 0;
+			let edited = "";
+			let deleted = "";
+			dialog.onNew = () => {
+				newCount++;
+			};
+			dialog.onEdit = (category) => {
+				edited = category.id;
+			};
+			dialog.onDelete = (category) => {
+				deleted = category.id;
+			};
+
+			dialog.open(CATEGORIES);
+			dialog.handleInput(key("n"));
+			dialog.handleInput(key("e"));
+			dialog.handleInput(key("d"));
+
+			expect(newCount).toBe(1);
+			expect(edited).toBe("anime");
+			expect(deleted).toBe("anime");
+		} finally {
+			renderer.destroy();
+		}
+	});
+});
+
+function key(name: string): KeyEvent {
+	return {
+		ctrl: false,
+		eventType: "press",
+		meta: false,
+		name,
+		option: false,
+		repeated: false,
+		sequence: name,
+		shift: false,
+		preventDefault: () => {},
+		stopPropagation: () => {},
+	} as KeyEvent;
+}

--- a/tests/layout/category-select-dialog.test.ts
+++ b/tests/layout/category-select-dialog.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import type { KeyEvent } from "@opentui/core";
+import { createTestRenderer } from "@opentui/core/testing";
+import { CategorySelectDialog } from "../../src/layout/category-select-dialog.ts";
+import type { CategoryState } from "../../src/store/index.ts";
+import type { LayoutDimensions } from "../../src/types/layout.ts";
+
+const TEST_LAYOUT: LayoutDimensions = {
+	terminal: { width: 80, height: 24 },
+	sidebar: { x: 0, y: 0, width: 20, height: 23 },
+	content: { x: 20, y: 0, width: 60, height: 23 },
+	statusBar: { x: 0, y: 23, width: 80, height: 1 },
+};
+
+const CATEGORIES: CategoryState[] = [
+	{ id: "anime", name: "Anime", savePath: "/anime" },
+	{ id: "linux", name: "Linux ISOs", savePath: null },
+];
+
+describe("CategorySelectDialog", () => {
+	test("shows category choices with effective add paths", async () => {
+		const { captureCharFrame, renderer, renderOnce } = await createTestRenderer(
+			{
+				width: 80,
+				height: 24,
+			},
+		);
+		try {
+			const dialog = new CategorySelectDialog(renderer, TEST_LAYOUT);
+
+			dialog.open({
+				categories: [
+					{
+						id: "long",
+						name: "Long Path",
+						savePath: `${homedir()}/Downloads/torrents/really/long/category/path`,
+					},
+					...CATEGORIES,
+				],
+				defaultCategoryId: "anime",
+				globalDownloadPath: `${homedir()}/Downloads`,
+				mode: "add",
+			});
+			await renderOnce();
+
+			const frame = captureCharFrame();
+			expect(frame).toContain("Select category");
+			expect(frame).toContain("None");
+			expect(frame).toContain("~/Downloads");
+			expect(frame).not.toContain(homedir());
+			expect(frame).toContain("~/Downloads/…ategory/path");
+			expect(frame).toContain("Long Path");
+			expect(frame).toContain("Anime");
+			expect(frame).toContain("/anime");
+			expect(frame).toContain("Linux ISOs");
+		} finally {
+			renderer.destroy();
+		}
+	});
+
+	test("n opens new category and b is consumed without browsing", async () => {
+		const { renderer } = await createTestRenderer({
+			width: 80,
+			height: 24,
+		});
+		try {
+			const dialog = new CategorySelectDialog(renderer, TEST_LAYOUT);
+			let newCategoryCount = 0;
+			let selected = "";
+			dialog.onNewCategory = () => {
+				newCategoryCount++;
+			};
+			dialog.onSelect = (category) => {
+				selected = category?.id ?? "none";
+			};
+
+			dialog.open({
+				categories: CATEGORIES,
+				globalDownloadPath: "/downloads",
+				mode: "add",
+			});
+
+			expect(dialog.handleInput(key("b"))).toBe(true);
+			expect(newCategoryCount).toBe(0);
+			expect(selected).toBe("");
+			expect(dialog.getIsOpen()).toBe(true);
+
+			expect(dialog.handleInput(key("n"))).toBe(true);
+			expect(newCategoryCount).toBe(1);
+			expect(dialog.getIsOpen()).toBe(true);
+		} finally {
+			renderer.destroy();
+		}
+	});
+});
+
+function key(name: string): KeyEvent {
+	return {
+		ctrl: false,
+		eventType: "press",
+		meta: false,
+		name,
+		option: false,
+		repeated: false,
+		sequence: name,
+		shift: false,
+		preventDefault: () => {},
+		stopPropagation: () => {},
+	} as KeyEvent;
+}

--- a/tests/layout/confirm-dialog-controller.test.ts
+++ b/tests/layout/confirm-dialog-controller.test.ts
@@ -343,6 +343,48 @@ describe("delete confirmation controller flow", () => {
 			renderer.destroy();
 		}
 	});
+
+	test("cancels pending throttled renders when stopped", async () => {
+		const { renderer } = await createTestRenderer({
+			width: 80,
+			height: 24,
+		});
+		try {
+			const store = new Store({
+				selectedIndex: 0,
+				selectedView: "All",
+				torrents: [],
+				totalDownloadBps: 0,
+				totalUploadBps: 0,
+			});
+			const sidebar = createCountingRenderable();
+			const content = createCountingRenderable();
+			const status = createCountingRenderable();
+			const controller = new AppController(
+				renderer,
+				store,
+				sidebar as never,
+				content as never,
+				status as never,
+				{
+					handleInput: () => false,
+					show: () => {},
+				} as never,
+			);
+			controller.start();
+			const initialUpdates = content.updateCount;
+
+			store.setState({ totalDownloadBps: 1 });
+			controller.stop();
+			await new Promise((resolve) => setTimeout(resolve, 120));
+
+			expect(sidebar.updateCount).toBe(initialUpdates);
+			expect(content.updateCount).toBe(initialUpdates);
+			expect(status.updateCount).toBe(initialUpdates);
+		} finally {
+			renderer.destroy();
+		}
+	});
 });
 
 function callHandleKeyPress(

--- a/tests/layout/confirm-dialog-controller.test.ts
+++ b/tests/layout/confirm-dialog-controller.test.ts
@@ -38,6 +38,7 @@ describe("delete confirmation controller flow", () => {
 			width: 80,
 			height: 24,
 		});
+		let controller: AppController | null = null;
 		try {
 			const store = new Store({
 				selectedIndex: 0,
@@ -68,7 +69,7 @@ describe("delete confirmation controller flow", () => {
 				totalDownloadBps: 0,
 				totalUploadBps: 0,
 			});
-			const controller = new AppController(
+			controller = new AppController(
 				renderer,
 				store,
 				createNoopRenderable() as never,
@@ -98,6 +99,7 @@ describe("delete confirmation controller flow", () => {
 			expect(confirmKey.stopped).toBe(true);
 			expect(controller.focusMode).toBe("global");
 		} finally {
+			controller?.stop();
 			renderer.destroy();
 		}
 	});
@@ -189,6 +191,7 @@ describe("delete confirmation controller flow", () => {
 			width: 80,
 			height: 24,
 		});
+		let controller: AppController | null = null;
 		try {
 			const store = new Store({
 				selectedIndex: 0,
@@ -200,7 +203,7 @@ describe("delete confirmation controller flow", () => {
 			const sidebar = createCountingRenderable();
 			const content = createCountingRenderable();
 			const status = createCountingRenderable();
-			const controller = new AppController(
+			controller = new AppController(
 				renderer,
 				store,
 				sidebar as never,
@@ -225,6 +228,7 @@ describe("delete confirmation controller flow", () => {
 			expect(content.updateCount).toBe(initialUpdates + 1);
 			expect(status.updateCount).toBe(initialUpdates + 1);
 		} finally {
+			controller?.stop();
 			renderer.destroy();
 		}
 	});
@@ -234,6 +238,7 @@ describe("delete confirmation controller flow", () => {
 			width: 80,
 			height: 24,
 		});
+		let controller: AppController | null = null;
 		try {
 			const store = new Store({
 				selectedIndex: 0,
@@ -245,7 +250,7 @@ describe("delete confirmation controller flow", () => {
 			const sidebar = createCountingRenderable();
 			const content = createCountingRenderable();
 			const status = createCountingRenderable();
-			const controller = new AppController(
+			controller = new AppController(
 				renderer,
 				store,
 				sidebar as never,
@@ -274,6 +279,7 @@ describe("delete confirmation controller flow", () => {
 			expect(content.updateCount).toBe(initialUpdates + 1);
 			expect(status.updateCount).toBe(initialUpdates + 1);
 		} finally {
+			controller?.stop();
 			renderer.destroy();
 		}
 	});
@@ -283,6 +289,7 @@ describe("delete confirmation controller flow", () => {
 			width: 80,
 			height: 24,
 		});
+		let controller: AppController | null = null;
 		try {
 			const store = new Store({
 				selectedIndex: 0,
@@ -314,7 +321,7 @@ describe("delete confirmation controller flow", () => {
 			const sidebar = createCountingRenderable();
 			const content = createCountingRenderable();
 			const status = createCountingRenderable();
-			const controller = new AppController(
+			controller = new AppController(
 				renderer,
 				store,
 				sidebar as never,
@@ -340,6 +347,7 @@ describe("delete confirmation controller flow", () => {
 			expect(content.updateCount).toBe(initialUpdates + 1);
 			expect(status.updateCount).toBe(initialUpdates + 1);
 		} finally {
+			controller?.stop();
 			renderer.destroy();
 		}
 	});
@@ -349,6 +357,7 @@ describe("delete confirmation controller flow", () => {
 			width: 80,
 			height: 24,
 		});
+		let controller: AppController | null = null;
 		try {
 			const store = new Store({
 				selectedIndex: 0,
@@ -360,7 +369,7 @@ describe("delete confirmation controller flow", () => {
 			const sidebar = createCountingRenderable();
 			const content = createCountingRenderable();
 			const status = createCountingRenderable();
-			const controller = new AppController(
+			controller = new AppController(
 				renderer,
 				store,
 				sidebar as never,
@@ -382,6 +391,7 @@ describe("delete confirmation controller flow", () => {
 			expect(content.updateCount).toBe(initialUpdates);
 			expect(status.updateCount).toBe(initialUpdates);
 		} finally {
+			controller?.stop();
 			renderer.destroy();
 		}
 	});

--- a/tests/layout/confirm-dialog-controller.test.ts
+++ b/tests/layout/confirm-dialog-controller.test.ts
@@ -33,6 +33,9 @@ describe("delete confirmation controller flow", () => {
 					{
 						id: "torrent-1",
 						name: "sample",
+						categoryId: null,
+						categoryName: null,
+						savePath: "/tmp",
 						targetPath: "/tmp/sample",
 						totalSize: 1,
 						pieceLength: 1,
@@ -81,6 +84,88 @@ describe("delete confirmation controller flow", () => {
 			expect(confirmKey.prevented).toBe(true);
 			expect(confirmKey.stopped).toBe(true);
 			expect(controller.focusMode).toBe("global");
+		} finally {
+			renderer.destroy();
+		}
+	});
+
+	test("dialog escape lets the app decide whether focus returns to global", async () => {
+		const { renderer } = await createTestRenderer({
+			width: 80,
+			height: 24,
+		});
+		try {
+			const store = new Store({
+				selectedIndex: 0,
+				selectedView: "All",
+				torrents: [],
+				totalDownloadBps: 0,
+				totalUploadBps: 0,
+			});
+			const controller = new AppController(
+				renderer,
+				store,
+				createNoopRenderable() as never,
+				createNoopRenderable() as never,
+				createNoopRenderable() as never,
+				{
+					handleInput: () => false,
+					show: () => {},
+				} as never,
+			);
+			let closeCount = 0;
+			controller.focusMode = "dialog";
+			controller.onDialogClose = () => {
+				closeCount++;
+			};
+
+			const escapeKey = keyEvent("escape", false);
+			callHandleKeyPress(controller, escapeKey);
+
+			expect(closeCount).toBe(1);
+			expect(controller.focusMode).toBe("dialog");
+			expect(escapeKey.prevented).toBe(true);
+			expect(escapeKey.stopped).toBe(true);
+		} finally {
+			renderer.destroy();
+		}
+	});
+
+	test("m opens category manager only from sidebar focus", async () => {
+		const { renderer } = await createTestRenderer({
+			width: 80,
+			height: 24,
+		});
+		try {
+			const store = new Store({
+				selectedIndex: 0,
+				selectedView: "All",
+				torrents: [],
+				totalDownloadBps: 0,
+				totalUploadBps: 0,
+			});
+			const controller = new AppController(
+				renderer,
+				store,
+				createNoopRenderable() as never,
+				createNoopRenderable() as never,
+				createNoopRenderable() as never,
+				{
+					handleInput: () => false,
+					show: () => {},
+				} as never,
+			);
+			let manageCount = 0;
+			controller.onManageCategories = () => {
+				manageCount++;
+			};
+			controller.focusArea = "table";
+			callHandleKeyPress(controller, keyEvent("m", false));
+			controller.focusArea = "sidebar";
+			callHandleKeyPress(controller, keyEvent("m", false));
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(manageCount).toBe(1);
 		} finally {
 			renderer.destroy();
 		}

--- a/tests/layout/confirm-dialog-controller.test.ts
+++ b/tests/layout/confirm-dialog-controller.test.ts
@@ -19,6 +19,19 @@ function createNoopRenderable() {
 	};
 }
 
+function createCountingRenderable() {
+	let updateCount = 0;
+	return {
+		get updateCount() {
+			return updateCount;
+		},
+		update: () => {
+			updateCount++;
+		},
+		getDetailBodyRowCount: () => 10,
+	};
+}
+
 describe("delete confirmation controller flow", () => {
 	test("confirms delete-with-files on the first y keypress", async () => {
 		const { renderer } = await createTestRenderer({
@@ -166,6 +179,166 @@ describe("delete confirmation controller flow", () => {
 			await new Promise((resolve) => setTimeout(resolve, 0));
 
 			expect(manageCount).toBe(1);
+		} finally {
+			renderer.destroy();
+		}
+	});
+
+	test("coalesces repeated store updates into throttled renders", async () => {
+		const { renderer } = await createTestRenderer({
+			width: 80,
+			height: 24,
+		});
+		try {
+			const store = new Store({
+				selectedIndex: 0,
+				selectedView: "All",
+				torrents: [],
+				totalDownloadBps: 0,
+				totalUploadBps: 0,
+			});
+			const sidebar = createCountingRenderable();
+			const content = createCountingRenderable();
+			const status = createCountingRenderable();
+			const controller = new AppController(
+				renderer,
+				store,
+				sidebar as never,
+				content as never,
+				status as never,
+				{
+					handleInput: () => false,
+					show: () => {},
+				} as never,
+			);
+			controller.start();
+			const initialUpdates = content.updateCount;
+
+			for (let i = 0; i < 20; i++) {
+				store.setState({ totalDownloadBps: i });
+			}
+
+			expect(content.updateCount).toBe(initialUpdates);
+			await new Promise((resolve) => setTimeout(resolve, 120));
+
+			expect(sidebar.updateCount).toBe(initialUpdates + 1);
+			expect(content.updateCount).toBe(initialUpdates + 1);
+			expect(status.updateCount).toBe(initialUpdates + 1);
+		} finally {
+			renderer.destroy();
+		}
+	});
+
+	test("coalesces tab spam into throttled renders", async () => {
+		const { renderer } = await createTestRenderer({
+			width: 80,
+			height: 24,
+		});
+		try {
+			const store = new Store({
+				selectedIndex: 0,
+				selectedView: "All",
+				torrents: [],
+				totalDownloadBps: 0,
+				totalUploadBps: 0,
+			});
+			const sidebar = createCountingRenderable();
+			const content = createCountingRenderable();
+			const status = createCountingRenderable();
+			const controller = new AppController(
+				renderer,
+				store,
+				sidebar as never,
+				content as never,
+				status as never,
+				{
+					handleInput: () => false,
+					show: () => {},
+				} as never,
+			);
+			controller.start();
+			const initialUpdates = content.updateCount;
+			const firstKey = keyEvent("tab", false);
+
+			callHandleKeyPress(controller, firstKey);
+			for (let i = 0; i < 99; i++) {
+				callHandleKeyPress(controller, keyEvent("tab", false));
+			}
+
+			expect(firstKey.prevented).toBe(true);
+			expect(firstKey.stopped).toBe(true);
+			expect(content.updateCount).toBe(initialUpdates);
+			await new Promise((resolve) => setTimeout(resolve, 120));
+
+			expect(sidebar.updateCount).toBe(initialUpdates + 1);
+			expect(content.updateCount).toBe(initialUpdates + 1);
+			expect(status.updateCount).toBe(initialUpdates + 1);
+		} finally {
+			renderer.destroy();
+		}
+	});
+
+	test("coalesces table navigation spam into throttled renders", async () => {
+		const { renderer } = await createTestRenderer({
+			width: 80,
+			height: 24,
+		});
+		try {
+			const store = new Store({
+				selectedIndex: 0,
+				selectedView: "All",
+				torrents: Array.from({ length: 200 }, (_, i) => ({
+					id: `torrent-${i}`,
+					name: `sample-${i}`,
+					categoryId: null,
+					categoryName: null,
+					savePath: "/tmp",
+					targetPath: `/tmp/sample-${i}`,
+					totalSize: 1,
+					pieceLength: 1,
+					downloadedPieces: 0,
+					totalPieces: 1,
+					status: "stopped" as const,
+					downloadBps: 0,
+					uploadBps: 0,
+					peers: 0,
+					seeds: 0,
+					leechers: 0,
+					peerDetails: [],
+					files: [],
+					etaSeconds: null,
+				})),
+				totalDownloadBps: 0,
+				totalUploadBps: 0,
+			});
+			const sidebar = createCountingRenderable();
+			const content = createCountingRenderable();
+			const status = createCountingRenderable();
+			const controller = new AppController(
+				renderer,
+				store,
+				sidebar as never,
+				content as never,
+				status as never,
+				{
+					handleInput: () => false,
+					show: () => {},
+				} as never,
+			);
+			controller.start();
+			controller.focusArea = "table";
+			const initialUpdates = content.updateCount;
+
+			for (let i = 0; i < 100; i++) {
+				callHandleKeyPress(controller, keyEvent("j", false));
+			}
+
+			expect(content.updateCount).toBe(initialUpdates);
+			await new Promise((resolve) => setTimeout(resolve, 120));
+
+			expect(sidebar.updateCount).toBe(initialUpdates + 1);
+			expect(content.updateCount).toBe(initialUpdates + 1);
+			expect(status.updateCount).toBe(initialUpdates + 1);
 		} finally {
 			renderer.destroy();
 		}

--- a/tests/layout/directory-picker-dialog.test.ts
+++ b/tests/layout/directory-picker-dialog.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { KeyEvent } from "@opentui/core";
+import { createTestRenderer } from "@opentui/core/testing";
+import { DirectoryPickerDialog } from "../../src/layout/directory-picker-dialog.ts";
+import type { LayoutDimensions } from "../../src/types/layout.ts";
+
+const TEST_LAYOUT: LayoutDimensions = {
+	terminal: { width: 80, height: 24 },
+	sidebar: { x: 0, y: 0, width: 20, height: 23 },
+	content: { x: 20, y: 0, width: 60, height: 23 },
+	statusBar: { x: 0, y: 23, width: 80, height: 1 },
+};
+
+describe("DirectoryPickerDialog", () => {
+	test("browses child directories and selects current directory", async () => {
+		await withWorkspaceTempDir(async (dir) => {
+			const child = join(dir, "Anime");
+			mkdirSync(child);
+			const { renderer } = await createTestRenderer({
+				width: 80,
+				height: 24,
+			});
+			try {
+				const dialog = new DirectoryPickerDialog(renderer, TEST_LAYOUT);
+				let selected = "";
+				dialog.onSelect = (path) => {
+					selected = path;
+				};
+
+				dialog.open(dir);
+				dialog.handleInput(key("down"));
+				dialog.handleInput(key("enter"));
+				dialog.handleInput(key("space"));
+
+				expect(selected).toBe(child);
+			} finally {
+				renderer.destroy();
+			}
+		});
+	});
+
+	test("starts at home when initial path is outside home", async () => {
+		const { captureCharFrame, renderer, renderOnce } = await createTestRenderer(
+			{
+				width: 80,
+				height: 24,
+			},
+		);
+		try {
+			const dialog = new DirectoryPickerDialog(renderer, TEST_LAYOUT);
+
+			dialog.open("/tmp");
+			await renderOnce();
+
+			const frame = captureCharFrame();
+			expect(frame).toContain(homedir());
+			expect(frame).not.toContain("/tmp");
+			expect(frame).not.toContain("..");
+		} finally {
+			renderer.destroy();
+		}
+	});
+});
+
+async function withWorkspaceTempDir<T>(
+	fn: (dir: string) => T | Promise<T>,
+): Promise<T> {
+	const dir = mkdtempSync(join(process.cwd(), ".directory-picker-test-"));
+	try {
+		return await fn(dir);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+function key(name: string): KeyEvent {
+	return {
+		ctrl: false,
+		eventType: "press",
+		meta: false,
+		name,
+		option: false,
+		repeated: false,
+		sequence: name,
+		shift: false,
+		preventDefault: () => {},
+		stopPropagation: () => {},
+	} as KeyEvent;
+}

--- a/tests/layout/directory-picker-dialog.test.ts
+++ b/tests/layout/directory-picker-dialog.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, relative } from "node:path";
 import type { KeyEvent } from "@opentui/core";
 import { createTestRenderer } from "@opentui/core/testing";
 import { DirectoryPickerDialog } from "../../src/layout/directory-picker-dialog.ts";
@@ -63,12 +63,43 @@ describe("DirectoryPickerDialog", () => {
 			renderer.destroy();
 		}
 	});
+
+	test("rejects folder names that escape the current directory", async () => {
+		await withWorkspaceTempDir(async (dir) => {
+			const { captureCharFrame, renderer, renderOnce } =
+				await createTestRenderer({
+					width: 80,
+					height: 24,
+				});
+			try {
+				const dialog = new DirectoryPickerDialog(renderer, TEST_LAYOUT);
+
+				dialog.open(dir);
+				dialog.handleInput(key("n"));
+				dialog.handleInput(key("."));
+				dialog.handleInput(key("."));
+				dialog.handleInput(key("enter"));
+				await renderOnce();
+
+				expect(captureCharFrame()).toContain(
+					"Folder name cannot include path segments",
+				);
+			} finally {
+				renderer.destroy();
+			}
+		});
+	});
 });
 
 async function withWorkspaceTempDir<T>(
 	fn: (dir: string) => T | Promise<T>,
 ): Promise<T> {
-	const dir = mkdtempSync(join(process.cwd(), ".directory-picker-test-"));
+	const cwdFromHome = relative(homedir(), process.cwd());
+	const base =
+		cwdFromHome && !cwdFromHome.startsWith("..") && !isAbsolute(cwdFromHome)
+			? join(homedir(), cwdFromHome)
+			: homedir();
+	const dir = mkdtempSync(join(base, ".directory-picker-test-"));
 	try {
 		return await fn(dir);
 	} finally {

--- a/tests/layout/sidebar.test.ts
+++ b/tests/layout/sidebar.test.ts
@@ -1,20 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { buildSidebarSelectableItems } from "../../src/layout/sidebar.ts";
-import type { AppState } from "../../src/store/index.ts";
 
 describe("sidebar rows", () => {
 	test("shows only status filters", () => {
-		const state: AppState = {
-			selectedIndex: 0,
-			selectedView: "Downloading",
-			searchQuery: "",
-			categories: [{ id: "anime", name: "Anime", savePath: "/media/anime" }],
-			torrents: [],
-			totalDownloadBps: 0,
-			totalUploadBps: 0,
-		};
+		const items = buildSidebarSelectableItems();
 
-		expect(buildSidebarSelectableItems().map((item) => item.label)).toEqual([
+		expect(items.map((item) => item.label)).toEqual([
 			"All",
 			"Downloading",
 			"Paused",
@@ -22,26 +13,15 @@ describe("sidebar rows", () => {
 			"Completed",
 			"Stopped",
 		]);
-		expect(state.categories).toHaveLength(1);
+		expect(items.every((item) => item.label === item.selectedView)).toBe(true);
 	});
 
 	test("status rows select matching status views", () => {
-		const state: AppState = {
-			selectedIndex: 0,
-			selectedView: "Stopped",
-			searchQuery: "",
-			categories: [{ id: "anime", name: "Anime", savePath: "/media/anime" }],
-			torrents: [],
-			totalDownloadBps: 0,
-			totalUploadBps: 0,
-		};
-
 		const items = buildSidebarSelectableItems();
 
 		expect(items.find((item) => item.label === "Stopped")).toMatchObject({
 			selectedView: "Stopped",
 		});
 		expect(items.find((item) => item.label === "Anime")).toBeUndefined();
-		expect(state.selectedView).toBe("Stopped");
 	});
 });

--- a/tests/layout/sidebar.test.ts
+++ b/tests/layout/sidebar.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { buildSidebarSelectableItems } from "../../src/layout/sidebar.ts";
+import type { AppState } from "../../src/store/index.ts";
+
+describe("sidebar rows", () => {
+	test("shows only status filters", () => {
+		const state: AppState = {
+			selectedIndex: 0,
+			selectedView: "Downloading",
+			searchQuery: "",
+			categories: [{ id: "anime", name: "Anime", savePath: "/media/anime" }],
+			torrents: [],
+			totalDownloadBps: 0,
+			totalUploadBps: 0,
+		};
+
+		expect(buildSidebarSelectableItems().map((item) => item.label)).toEqual([
+			"All",
+			"Downloading",
+			"Paused",
+			"Seeding",
+			"Completed",
+			"Stopped",
+		]);
+		expect(state.categories).toHaveLength(1);
+	});
+
+	test("status rows select matching status views", () => {
+		const state: AppState = {
+			selectedIndex: 0,
+			selectedView: "Stopped",
+			searchQuery: "",
+			categories: [{ id: "anime", name: "Anime", savePath: "/media/anime" }],
+			torrents: [],
+			totalDownloadBps: 0,
+			totalUploadBps: 0,
+		};
+
+		const items = buildSidebarSelectableItems();
+
+		expect(items.find((item) => item.label === "Stopped")).toMatchObject({
+			selectedView: "Stopped",
+		});
+		expect(items.find((item) => item.label === "Anime")).toBeUndefined();
+		expect(state.selectedView).toBe("Stopped");
+	});
+});

--- a/tests/torrent/category-bridge.test.ts
+++ b/tests/torrent/category-bridge.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Store } from "../../src/store/index.ts";
+import { TorrentBridge } from "../../src/torrent/bridge.ts";
+import { writeResumeData } from "../../src/torrent/resume.ts";
+import { StorageManager } from "../../src/torrent/storage.ts";
+import { splitPieces } from "../helpers/bytes.ts";
+import { withIsolatedAppData, withTempDir } from "../helpers/temp.ts";
+import { singleFileTorrentFixture } from "../helpers/torrent-fixtures.ts";
+
+function createStore(): Store {
+	return new Store({
+		selectedIndex: 0,
+		selectedView: "All",
+		torrents: [],
+		totalDownloadBps: 0,
+		totalUploadBps: 0,
+	});
+}
+
+describe("TorrentBridge categories and frozen save paths", () => {
+	test("confirmAdd persists category and frozen save path", async () => {
+		await withIsolatedAppData(async () => {
+			await withTempDir(async (dir) => {
+				const fixture = singleFileTorrentFixture();
+				const torrentPath = join(dir, "fixture.torrent");
+				const savePath = join(dir, "anime");
+				writeFileSync(torrentPath, fixture.raw);
+				const store = createStore();
+				const bridge = new TorrentBridge(store, {
+					downloadPath: join(dir, "default"),
+					torrentFolder: dir,
+				});
+
+				const prepared = await bridge.prepareAdd(torrentPath);
+				await bridge.confirmAdd(prepared, {
+					categoryId: "anime",
+					categoryName: "Anime",
+					savePath,
+				});
+
+				expect(store.getState().torrents[0]).toMatchObject({
+					categoryId: "anime",
+					categoryName: "Anime",
+					savePath,
+					targetPath: join(savePath, fixture.metadata.name),
+				});
+
+				const registry = JSON.parse(
+					readFileSync(
+						join(getXdgDataHome(), "torrent-tui", "session.json"),
+						"utf-8",
+					),
+				);
+				expect(registry.schemaVersion).toBe(2);
+				expect(registry.torrents[0]).toMatchObject({
+					categoryId: "anime",
+					categoryName: "Anime",
+					savePath,
+				});
+			});
+		});
+	});
+
+	test("restore uses v2 saved path instead of global download path", async () => {
+		await withIsolatedAppData(async () => {
+			await withTempDir(async (dir) => {
+				const fixture = singleFileTorrentFixture();
+				const torrentPath = join(dir, "fixture.torrent");
+				const savePath = join(dir, "frozen");
+				writeFileSync(torrentPath, fixture.raw);
+				const storage = new StorageManager(fixture.metadata, savePath);
+				await storage.setup();
+				const firstPiece = splitPieces(
+					fixture.content,
+					fixture.metadata.pieceLength,
+				)[0];
+				if (!firstPiece) throw new Error("missing first piece");
+				storage.writePieceSync(0, firstPiece);
+				writeResumeData(fixture.metadata, savePath, [0]);
+				writeRegistry(dir, torrentPath, savePath, "anime", "Anime");
+
+				const store = createStore();
+				const bridge = new TorrentBridge(store, {
+					downloadPath: join(dir, "default"),
+					torrentFolder: dir,
+				});
+
+				await bridge.restoreSession();
+
+				expect(store.getState().torrents[0]).toMatchObject({
+					categoryId: "anime",
+					downloadedPieces: 1,
+					savePath,
+					status: "stopped",
+				});
+			});
+		});
+	});
+
+	test("changing category does not mutate frozen save path", async () => {
+		await withIsolatedAppData(async () => {
+			await withTempDir(async (dir) => {
+				const fixture = singleFileTorrentFixture();
+				const torrentPath = join(dir, "fixture.torrent");
+				const savePath = join(dir, "frozen");
+				writeFileSync(torrentPath, fixture.raw);
+				const store = createStore();
+				const bridge = new TorrentBridge(store, {
+					downloadPath: join(dir, "default"),
+					torrentFolder: dir,
+				});
+				const prepared = await bridge.prepareAdd(torrentPath);
+				await bridge.confirmAdd(prepared, {
+					categoryId: "anime",
+					categoryName: "Anime",
+					savePath,
+				});
+				const before = store.getState().torrents[0];
+				if (!before) throw new Error("missing torrent state");
+
+				bridge.setTorrentCategory(before.id, {
+					id: "movies",
+					name: "Movies",
+				});
+
+				expect(store.getState().torrents[0]).toMatchObject({
+					categoryId: "movies",
+					categoryName: "Movies",
+					savePath: before.savePath,
+					targetPath: before.targetPath,
+				});
+			});
+		});
+	});
+
+	test("renaming category updates torrent category names only", async () => {
+		await withIsolatedAppData(async () => {
+			await withTempDir(async (dir) => {
+				const fixture = singleFileTorrentFixture();
+				const torrentPath = join(dir, "fixture.torrent");
+				const savePath = join(dir, "frozen");
+				writeFileSync(torrentPath, fixture.raw);
+				const store = createStore();
+				const bridge = new TorrentBridge(store, {
+					downloadPath: join(dir, "default"),
+					torrentFolder: dir,
+				});
+				const prepared = await bridge.prepareAdd(torrentPath);
+				await bridge.confirmAdd(prepared, {
+					categoryId: "anime",
+					categoryName: "Anime",
+					savePath,
+				});
+				const before = store.getState().torrents[0];
+				if (!before) throw new Error("missing torrent state");
+
+				bridge.renameCategory("anime", "Animation");
+
+				expect(store.getState().torrents[0]).toMatchObject({
+					categoryId: "anime",
+					categoryName: "Animation",
+					savePath: before.savePath,
+					targetPath: before.targetPath,
+				});
+			});
+		});
+	});
+
+	test("clearing category uncategorizes torrents without moving files", async () => {
+		await withIsolatedAppData(async () => {
+			await withTempDir(async (dir) => {
+				const fixture = singleFileTorrentFixture();
+				const torrentPath = join(dir, "fixture.torrent");
+				const savePath = join(dir, "frozen");
+				writeFileSync(torrentPath, fixture.raw);
+				const store = createStore();
+				const bridge = new TorrentBridge(store, {
+					downloadPath: join(dir, "default"),
+					torrentFolder: dir,
+				});
+				const prepared = await bridge.prepareAdd(torrentPath);
+				await bridge.confirmAdd(prepared, {
+					categoryId: "anime",
+					categoryName: "Anime",
+					savePath,
+				});
+				const before = store.getState().torrents[0];
+				if (!before) throw new Error("missing torrent state");
+
+				bridge.clearCategory("anime");
+
+				expect(store.getState().torrents[0]).toMatchObject({
+					categoryId: null,
+					categoryName: null,
+					savePath: before.savePath,
+					targetPath: before.targetPath,
+				});
+			});
+		});
+	});
+
+	test("v1 registry restore falls back to global download path", async () => {
+		await withIsolatedAppData(async () => {
+			await withTempDir(async (dir) => {
+				const fixture = singleFileTorrentFixture();
+				const torrentPath = join(dir, "fixture.torrent");
+				writeFileSync(torrentPath, fixture.raw);
+				writeRegistry(dir, torrentPath, undefined, undefined, undefined, 1);
+				const store = createStore();
+				const bridge = new TorrentBridge(store, {
+					downloadPath: dir,
+					torrentFolder: dir,
+				});
+
+				await bridge.restoreSession();
+
+				expect(store.getState().torrents[0]?.savePath).toBe(dir);
+			});
+		});
+	});
+
+	test("delete with files removes from frozen save path", async () => {
+		await withIsolatedAppData(async () => {
+			await withTempDir(async (dir) => {
+				const fixture = singleFileTorrentFixture();
+				const torrentPath = join(dir, "fixture.torrent");
+				const savePath = join(dir, "frozen");
+				writeFileSync(torrentPath, fixture.raw);
+				mkdirSync(savePath, { recursive: true });
+				writeFileSync(join(savePath, fixture.metadata.name), fixture.content);
+				const store = createStore();
+				const bridge = new TorrentBridge(store, {
+					downloadPath: join(dir, "default"),
+					torrentFolder: dir,
+				});
+				const prepared = await bridge.prepareAdd(torrentPath);
+				await bridge.confirmAdd(prepared, {
+					categoryId: null,
+					categoryName: null,
+					savePath,
+				});
+
+				await bridge.removeTorrent(prepared.id, true);
+
+				expect(existsSync(join(savePath, fixture.metadata.name))).toBe(false);
+			});
+		});
+	});
+});
+
+function writeRegistry(
+	_dir: string,
+	torrentPath: string,
+	savePath?: string,
+	categoryId?: string,
+	categoryName?: string,
+	schemaVersion = 2,
+): void {
+	const fixture = singleFileTorrentFixture();
+	const infoHash = Buffer.from(fixture.metadata.infoHash).toString("hex");
+	const registryDir = join(getXdgDataHome(), "torrent-tui");
+	mkdirSync(registryDir, { recursive: true });
+	writeFileSync(
+		join(registryDir, "session.json"),
+		JSON.stringify({
+			schemaVersion,
+			torrents: [
+				{
+					infoHash,
+					torrentPath,
+					...(savePath ? { savePath } : {}),
+					...(categoryId ? { categoryId } : {}),
+					...(categoryName ? { categoryName } : {}),
+				},
+			],
+		}),
+	);
+}
+
+function getXdgDataHome(): string {
+	const dataHome = process.env.XDG_DATA_HOME;
+	if (!dataHome) throw new Error("XDG_DATA_HOME is not set");
+	return dataHome;
+}

--- a/tests/utils/filter.test.ts
+++ b/tests/utils/filter.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import type { TorrentState } from "../../src/store/index.ts";
+import { filterTorrents } from "../../src/utils/filter.ts";
+
+function torrent(
+	id: string,
+	name: string,
+	status: TorrentState["status"],
+	categoryId: string | null,
+): TorrentState {
+	return {
+		id,
+		name,
+		categoryId,
+		categoryName: categoryId ? categoryId : null,
+		savePath: "/downloads",
+		targetPath: `/downloads/${name}`,
+		totalSize: 1,
+		pieceLength: 1,
+		downloadedPieces: 0,
+		totalPieces: 1,
+		status,
+		downloadBps: 0,
+		uploadBps: 0,
+		peers: 0,
+		seeds: 0,
+		leechers: 0,
+		peerDetails: [],
+		files: [],
+		etaSeconds: null,
+	};
+}
+
+describe("filterTorrents", () => {
+	const torrents = [
+		torrent("1", "Anime Movie", "downloading", "anime"),
+		torrent("2", "Linux ISO", "seeding", null),
+		torrent("3", "Anime OVA", "paused", "anime"),
+	];
+
+	test("composes status and name search", () => {
+		const result = filterTorrents(torrents, {
+			searchQuery: "movie",
+			view: "Downloading",
+		});
+
+		expect(result.map((t) => t.id)).toEqual(["1"]);
+	});
+
+	test("does not filter uncategorized torrents", () => {
+		const result = filterTorrents(torrents, {
+			view: "All",
+		});
+
+		expect(result.map((t) => t.id)).toEqual(["1", "2", "3"]);
+	});
+
+	test("keeps search name-only", () => {
+		const result = filterTorrents(torrents, {
+			searchQuery: "anime",
+			view: "All",
+		});
+
+		expect(result.map((t) => t.id)).toEqual(["1", "3"]);
+	});
+});

--- a/tests/utils/filter.test.ts
+++ b/tests/utils/filter.test.ts
@@ -47,6 +47,12 @@ describe("filterTorrents", () => {
 		expect(result.map((t) => t.id)).toEqual(["1"]);
 	});
 
+	test("keeps legacy string view filtering", () => {
+		const result = filterTorrents(torrents, "Downloading");
+
+		expect(result.map((t) => t.id)).toEqual(["1"]);
+	});
+
 	test("does not filter uncategorized torrents", () => {
 		const result = filterTorrents(torrents, {
 			view: "All",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Category management UI (create/rename/delete) with assign/reassign and per-torrent save-paths.
  * Two-step add flow: prepare + confirm, category selection, and directory picker dialog.
  * Search mode (enter with /) with search-aware hints and filtered torrent list.
  * New dialogs: category, manager, selector, directory picker; sidebar selectable items; throttled rendering.

* **Documentation**
  * Expanded implementation roadmap and BitTorrent protocol reference.

* **Tests**
  * Added tests for categories, dialogs, directory picker, filtering, and bridge/category restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->